### PR TITLE
update references to pis to 3, not explicitly 3+

### DIFF
--- a/BOM.md
+++ b/BOM.md
@@ -7,7 +7,7 @@ builds on the one before it.
 
 | Item                                                                    | Qty | Unit  | Subtotal  | Vendor                   |
 | ----------------------------------------------------------------------- | --- | ----- | --------- | ------------------------ |
-| Raspberry Pi 3 Model B+                                                 | 2   | $35   | $70       | Adafruit / PiShop        |
+| Raspberry Pi 3 Model B (optionally, 3+)                                 | 2   | $35   | $70       | Adafruit / PiShop        |
 | TP-Link TL-SG108E 8-port managed switch                                 | 1   | $30   | $30       | Amazon                   |
 | SanDisk Ultra 16GB microSD, A1-rated                                    | 3   | $12   | $36       | Amazon (sold by SanDisk) |
 | Official Raspberry Pi 12.5W micro-USB PSU                               | 2   | $8    | $16       | Adafruit / PiShop        |
@@ -20,7 +20,7 @@ builds on the one before it.
 
 | Item                                                                              | Qty | Unit  | Subtotal  | Vendor                   |
 | --------------------------------------------------------------------------------- | --- | ----- | --------- | ------------------------ |
-| Raspberry Pi 3 Model B+ (router)                                                  | 1   | $35   | $35       | Adafruit / PiShop        |
+| Raspberry Pi 3 Model B (optionally, 3+) (router)                                  | 1   | $35   | $35       | Adafruit / PiShop        |
 | USB 3.0 to Gigabit Ethernet adapter, AX88179A chipset (Plugable / Anker / UGreen) | 1   | $15   | $15       | Amazon / Adafruit        |
 | TP-Link TL-SG108E (second switch)                                                 | 1   | $30   | $30       | Amazon                   |
 | Official Raspberry Pi 12.5W micro-USB PSU                                         | 1   | $8    | $8        | Adafruit / PiShop        |
@@ -33,7 +33,7 @@ builds on the one before it.
 
 | Item                                                  | Qty | Unit  | Subtotal  | Vendor                   |
 | ----------------------------------------------------- | --- | ----- | --------- | ------------------------ |
-| Raspberry Pi 3 Model B+ (AS routers)                  | 2   | $35   | $70       | Adafruit / PiShop        |
+| Raspberry Pi 3 Model B (optionally, 3+) (AS routers)  | 2   | $35   | $70       | Adafruit / PiShop        |
 | USB 3.0 to Gigabit Ethernet adapter, AX88179A chipset | 2   | $15   | $30       | Amazon / Adafruit        |
 | Official Raspberry Pi 12.5W micro-USB PSU             | 2   | $8    | $16       | Adafruit / PiShop        |
 | SanDisk Ultra 16GB microSD, A1-rated                  | 2   | $12   | $24       | Amazon (sold by SanDisk) |

--- a/image/README.md
+++ b/image/README.md
@@ -239,9 +239,9 @@ build joins your Wi-Fi headless on first boot. Credentials live only in
 ### Notes & knobs
 
 - **Architecture.** Builds 64-bit (arm64) Raspberry Pi OS Lite by default. It
-  runs well on the Pi 3 Model B+ and, on an Apple Silicon Mac, builds natively
+  runs well on the Pi 3 Model B (or 3+) and, on an Apple Silicon Mac, builds natively
   without emulation. Both 32-bit and 64-bit flash and boot identically on the Pi
-  3 B+, so this is purely a build-host convenience.
+  3 B (or 3+), so this is purely a build-host convenience.
 - **pi-gen branch must match the release.** pi-gen pairs each Debian release
   with its own branch, and the branch must match `RELEASE` in `config` or pi-gen
   warns (`RELEASE does not match the intended option for this branch`) and may


### PR DESCRIPTION
I thought I bought 3+s, but I bought 3s myself. Whoops. Either works, but let's default to 3.