### PR TITLE
Disable first-boot user rename to stop spurious SSH banner

### DIFF
--- a/image/config
+++ b/image/config
@@ -31,6 +31,17 @@ TARGET_HOSTNAME='pi-node'
 FIRST_USER_NAME='pi'
 FIRST_USER_PASS='little-internet'
 
+# Keep the 'pi' user as a permanent account instead of pi-gen's default
+# behavior of treating it as build-only and forcing a "create your real user"
+# step on first boot. With the default (rename enabled), Raspberry Pi OS arms
+# the userconf-pi first-boot flow and shows an SSH pre-login banner — "Please
+# note that SSH may not work until a valid user has been set up" — until that
+# flow completes, which never happens on our headless image. Setting this to 1
+# disables the rename so 'pi' is stable and the banner goes away. Requires
+# FIRST_USER_PASS to be set (above). Tradeoff: we intentionally ship a known
+# default username/password — fine for a closed lab, not for exposed nodes.
+DISABLE_FIRST_BOOT_USER_RENAME=1
+
 # Enable SSH so nodes are reachable headless out of the box.
 ENABLE_SSH=1
 


### PR DESCRIPTION
pi-gen defaults `DISABLE_FIRST_BOOT_USER_RENAME=0`, which treats the baked-in `pi` user as build-only and arms the `userconf-pi` first-boot flow. On our headless image that flow never completes, so Raspberry Pi OS shows an SSH pre-login banner — "Please note that SSH may not work until a valid user has been set up" — on every login even though SSH works fine. This sets the flag to `1` in `image/config` so `pi` is a permanent account and the banner goes away (`FIRST_USER_PASS` is already set, as required). The tradeoff, noted in the config comment, is that we intentionally ship a known default username/password — fine for a closed lab, not for exposed nodes. Only affects newly built images; already-flashed cards still show the banner.