### PR TITLE
Switch OLED support from I2C to SPI; add OLED test tools

### DIFF
--- a/BOM.md
+++ b/BOM.md
@@ -5,16 +5,16 @@ builds on the one before it.
 
 ## Phase 1: a network (~$198)
 
-| Item                                                                    | Qty | Unit  | Subtotal  | Vendor                   |
-| ----------------------------------------------------------------------- | --- | ----- | --------- | ------------------------ |
-| Raspberry Pi 3 Model B (optionally, 3+)                                 | 2   | $35   | $70       | Adafruit / PiShop        |
-| TP-Link TL-SG108E 8-port managed switch                                 | 1   | $30   | $30       | Amazon                   |
-| SanDisk Ultra 16GB microSD, A1-rated                                    | 3   | $12   | $36       | Amazon (sold by SanDisk) |
-| Official Raspberry Pi 12.5W micro-USB PSU                               | 2   | $8    | $16       | Adafruit / PiShop        |
-| Monoprice SlimRun Cat6A 1ft (single color)                              | 5   | $2.50 | $12       | Monoprice                |
-| Adafruit SSD1306 128×64 OLED, 0.96" (bare breakout, requires soldering) | 2   | $15   | $30       | Adafruit                 |
-| Female-to-female jumper wires (40-pack)                                 | 1   | $4    | $4        | Adafruit / Amazon        |
-| **Phase 1 total**                                                       |     |       | **~$198** |                          |
+| Item                                                                                | Qty | Unit  | Subtotal  | Vendor                   |
+| ----------------------------------------------------------------------------------- | --- | ----- | --------- | ------------------------ |
+| Raspberry Pi 3 Model B (optionally, 3+)                                             | 2   | $35   | $70       | Adafruit / PiShop        |
+| TP-Link TL-SG108E 8-port managed switch                                             | 1   | $30   | $30       | Amazon                   |
+| SanDisk Ultra 16GB microSD, A1-rated                                                | 3   | $12   | $36       | Amazon (sold by SanDisk) |
+| Official Raspberry Pi 12.5W micro-USB PSU                                           | 2   | $8    | $16       | Adafruit / PiShop        |
+| Monoprice SlimRun Cat6A 1ft (single color)                                          | 5   | $2.50 | $12       | Monoprice                |
+| Adafruit SSD1306 128×64 OLED, 0.96" (4-wire SPI, bare breakout, requires soldering) | 2   | $15   | $30       | Adafruit                 |
+| Female-to-female jumper wires (40-pack)                                             | 1   | $4    | $4        | Adafruit / Amazon        |
+| **Phase 1 total**                                                                   |     |       | **~$198** |                          |
 
 ## Phase 2: two networks (+~$112, running ~$310)
 

--- a/image/README.md
+++ b/image/README.md
@@ -90,7 +90,12 @@ file in place so you can fix it and reboot.
   the password one last time). After that, `ssh pi@<hostname>.local` logs in
   with no prompt.
 - Confirm the networking tools are present: `which tcpdump tshark arping`.
-- Check the I2C bus (for the OLED): `i2cdetect -y 1`.
+- Check the OLED bus: the Phase 1 displays are **SPI** (not I2C), so confirm
+  `ls /dev/spidev*` lists `spidev0.0` and `spidev0.1`. The display library is
+  pre-installed in `/opt/little-internet/venv`; drive a panel with
+  `/opt/little-internet/venv/bin/python3` (the `tools/oled-test/` scripts in this
+  repo, `oled_test.py` and `oled_shrimp.py`, are ready-made smoke tests — copy
+  them onto the node with `scp`).
 - Wi-Fi is management-only by design: you can SSH in and the node reaches the
   internet, but two nodes **can't reach each other over Wi-Fi**. The lessons run
   on a wired link instead. So if a second node seems unreachable _from the first
@@ -126,9 +131,11 @@ image/
     ├── EXPORT_IMAGE              Marks this stage as exporting the final image.
     ├── 00-net-tools/
     │   ├── 00-debconf            Preseeds iperf3 to not autostart (keeps the build non-interactive).
-    │   ├── 00-packages           apt packages to install (capture, ARP, VLAN, I2C…).
-    │   ├── 01-run.sh             Enables the I2C bus for the SSD1306 OLED displays.
-    │   └── 02-run.sh             Installs a pre-provisioned Wi-Fi connection, if one was generated.
+    │   ├── 00-packages           apt packages to install (capture, ARP, VLAN, OLED/SPI…).
+    │   ├── 01-run.sh             Enables the SPI bus for the SSD1306 OLED displays.
+    │   ├── 02-run.sh             Installs a pre-provisioned Wi-Fi connection, if one was generated.
+    │   ├── 03-run.sh             Grants the user unprivileged packet capture + a ~/cap dir.
+    │   └── 04-run.sh             Builds the OLED display venv (luma.oled) at /opt/little-internet/venv.
     ├── 01-firstboot-config/      First-boot hostname + Wi-Fi provisioner for flashed (released) images.
     │   ├── 00-run.sh             Installs the provisioner script, service, and boot-partition template.
     │   └── files/                The script, systemd unit, and little-internet.txt.example.

--- a/image/stage-little-internet/00-net-tools/00-packages
+++ b/image/stage-little-internet/00-net-tools/00-packages
@@ -20,7 +20,12 @@ bridge-utils
 # RPi OS Lite doesn't ship the nft binary by default.
 nftables
 
-# I2C tooling + Python for the SSD1306 OLED displays in the Phase 1 BOM
-i2c-tools
+# Python + libraries for the SSD1306 *SPI* OLED displays in the Phase 1 BOM.
+# The compiled/heavy deps come from apt (prebuilt — no toolchain in the image);
+# the pure-python luma.oled library is layered on top via pip in 04-run.sh.
 python3
+python3-venv
 python3-pip
+python3-pil
+python3-spidev
+python3-rpi-lgpio

--- a/image/stage-little-internet/00-net-tools/01-run.sh
+++ b/image/stage-little-internet/00-net-tools/01-run.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -e
 
-# Enable the I2C bus so the SSD1306 OLED displays from the Phase 1 BOM work
-# out of the box. (raspi-config's "do_i2c 0" means *enable*.)
+# Enable the SPI bus so the SSD1306 OLED displays from the Phase 1 BOM work
+# out of the box. The Phase 1 OLEDs are 4-wire SPI (not I2C), so they show up
+# at /dev/spidev0.0 and /dev/spidev0.1 rather than on the I2C bus.
+# (raspi-config's "do_spi 0" means *enable*.)
 on_chroot << 'EOF'
-raspi-config nonint do_i2c 0
+raspi-config nonint do_spi 0
 EOF

--- a/image/stage-little-internet/00-net-tools/04-run.sh
+++ b/image/stage-little-internet/00-net-tools/04-run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+# Build a virtualenv with the OLED display library so the SSD1306 SPI panels in
+# the Phase 1 BOM work out of the box. luma.oled isn't packaged in apt, so it's
+# installed via pip; its compiled/heavy dependencies (Pillow, spidev, rpi-lgpio)
+# come from apt (see 00-packages) and are exposed through --system-site-packages,
+# so no compiler runs inside the image.
+#
+# The pip step needs network and is best-effort: if it fails the image still
+# builds with SPI enabled and the apt libraries present, and luma can be added
+# later with `sudo /opt/little-internet/venv/bin/pip install luma.oled`.
+on_chroot << 'EOF'
+python3 -m venv --system-site-packages /opt/little-internet/venv
+/opt/little-internet/venv/bin/pip install --no-input luma.oled \
+	|| echo "WARNING: luma.oled pip install failed; install it on-device later."
+EOF

--- a/tools/oled-test/.gitignore
+++ b/tools/oled-test/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tools/oled-test/README.md
+++ b/tools/oled-test/README.md
@@ -1,0 +1,79 @@
+# OLED test scripts
+
+Quick smoke tests for the **SSD1306 128×64** OLEDs over **4-wire SPI** (8-pin modules).
+
+- `oled_test.py` — draws a border + "OLED OK" so you can confirm the display works.
+- `oled_shrimp.py` — shows the Phosphor [`shrimp`](https://phosphoricons.com/?q=shrimp)
+  icon. The icon is baked in as a 64×64 1-bit bitmap, so no network or SVG libs
+  are needed on the Pi.
+
+> **These are SPI displays, not I2C.** They will **not** appear in `i2cdetect`.
+
+## Wiring (8-pin SPI SSD1306 → Pi 40-pin header)
+
+Read the labels on your board; common names are listed. This matches luma's SPI
+defaults, so the scripts run with no extra flags.
+
+| OLED pin            | Pi pin | GPIO         |
+|---------------------|--------|--------------|
+| GND                 | 6      | —            |
+| VCC                 | 1      | 3.3V         |
+| D0 / SCK / CLK      | 23     | GPIO11 (SCLK)|
+| D1 / MOSI / SDA/DIN | 19     | GPIO10 (MOSI)|
+| RES / RST           | 22     | GPIO25       |
+| DC                  | 18     | GPIO24       |
+| CS                  | 24     | GPIO8 (CE0)  |
+
+## On the Pi
+
+> **On the official little-internet image (v0.4.0+)** SPI is already enabled and
+> the library is pre-installed at `/opt/little-internet/venv`. Skip straight to
+> running the scripts with that interpreter:
+> `/opt/little-internet/venv/bin/python3 oled_test.py`. The steps below are for a
+> stock Raspberry Pi OS where you set this up yourself.
+
+```sh
+# 1. Enable SPI (one-time), then reboot
+sudo raspi-config nonint do_spi 0
+sudo reboot
+ls /dev/spidev*           # expect /dev/spidev0.0 and /dev/spidev0.1
+
+# 2. Install the OLED library + a GPIO backend (Pi OS Bookworm blocks
+#    system-wide pip, so use a venv). rpi-lgpio drives the DC/RST pins and
+#    works on all Pi models under Bookworm (the old RPi.GPIO is broken on Pi 5).
+python3 -m venv ~/oledvenv
+~/oledvenv/bin/pip install luma.oled rpi-lgpio
+
+# 3. Run a test — IMPORTANT: use the venv's python, not the system one.
+#    `python3 oled_test.py` uses /usr/bin/python3, which lacks these packages
+#    and fails with "No module named 'RPi'".
+~/oledvenv/bin/python3 oled_test.py
+~/oledvenv/bin/python3 oled_shrimp.py
+```
+
+> Quick-and-dirty alternative to the venv:
+> `sudo pip3 install luma.oled rpi-lgpio --break-system-packages` (then plain `python3` works).
+
+## Nothing on the screen?
+
+SPI has no acknowledgment, so the scripts print "Done" whether or not a display
+is actually there. A clean run with a dark panel means a **hardware** fault:
+
+- These are hand-soldered bare breakouts — a **cold solder joint** is the most
+  common cause. Power-off the board and continuity-test each joint
+  (OLED pad ↔ Pi header pin) with a multimeter on the Ω/200 range: near-0 = good,
+  `1`/overrange = open. Reflow any that fail. Also check adjacent pins aren't
+  bridged (those should read open).
+- **RST** and **D/C** are the usual culprits — open RST = controller never
+  resets; open D/C = every byte misread. Both yield a clean run and a dark screen.
+- Some 128×64 modules are **SH1106**, not SSD1306. If wiring checks out but the
+  image is garbled/offset, try `from luma.oled.device import sh1106`.
+- `3.3Vo` is a regulator **output** — leave it unconnected; only `VIN` gets power.
+
+## Options (both scripts)
+
+- `--device N` — SPI chip-select: `0`=CE0 (pin 24), `1`=CE1 (pin 26). Use this to
+  drive a **second** display wired to CE1 (sharing SCLK/MOSI/DC/RST).
+- `--port N` — SPI bus (default `0`).
+- `--dc N` / `--rst N` — DC / RST GPIO numbers (defaults 24 / 25).
+- `--hold SECONDS` — how long to leave the image up.

--- a/tools/oled-test/oled_shrimp.py
+++ b/tools/oled-test/oled_shrimp.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Show the Phosphor 'shrimp' icon on the SSD1306 128x64 OLED over 4-wire SPI.
+
+The icon is embedded as a 64x64 1-bit bitmap (rendered from the Phosphor
+regular 'shrimp' SVG, https://phosphoricons.com/?q=shrimp), so this script
+needs no network access or SVG libraries on the Pi.
+
+    python3 oled_shrimp.py                # uses CE0 + DC=GPIO24, RST=GPIO25
+    python3 oled_shrimp.py --device 1
+"""
+import argparse
+import base64
+import sys
+import time
+
+from PIL import Image
+
+from luma.core.interface.serial import spi
+from luma.oled.device import ssd1306
+
+# 64x64, 1-bit, MSB-first packed (PIL mode "1"). Phosphor "shrimp" (regular).
+SHRIMP_64_B64 = (
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAADwAAAAAAAAAPA"
+    "AAAAAAAAA+AAAAAAAAAB////8AAAAAH////4AAAAAP////wAAAAAP////gAAAAAAAAAfAA"
+    "AAAAAAAA8AAAAAAAAADwAAAAAAAAAPAAAAAAAAAA8AAAAAAAAAHwAAAP/////+AAAP////"
+    "//wAAD//////+AAAf//////wAAH/A8AAAPAAA/gDwAAA8AAH4APAAAHgAA/AA8AAAeAAD4"
+    "ADweAB4AAfAAPD8APgAD4AA8PwA8AAPAADw/AHwAB8AAPD8A+AAHwAA8HgHwAAfwADwAA/"
+    "AAD/wAPAAH4AAP/wA8AB/AAA9/4DwA/4AADx/4f//+AAAPB/7///wAAA8B////8AAADwA/"
+    "//8AAAAPAA/AAAAAAA8AB4AAAAAAB4AHgAAAAAAHgAeAAAAAAAeAH4AAAAAAB8A/wAAAAA"
+    "ADwH///+AAAAPh////8AAAAfP4///wAAAA/+B//+AAAAD/wDwAAAAAAH+APAAAAAAAP4A8"
+    "AAAAAAAf8DwAAAAAAAf///4AAAAAA////wAAAAAA////AAAAAAAP//4AAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+)
+
+
+def shrimp_image():
+    raw = base64.b64decode(SHRIMP_64_B64)
+    return Image.frombytes("1", (64, 64), raw)
+
+
+def main():
+    p = argparse.ArgumentParser(description="Show the Phosphor shrimp on an SPI OLED.")
+    p.add_argument("--port", type=int, default=0, help="SPI bus (default 0)")
+    p.add_argument("--device", type=int, default=0,
+                   help="SPI chip-select: 0=CE0 (pin 24), 1=CE1 (pin 26). Default 0.")
+    p.add_argument("--dc", type=int, default=24, help="DC GPIO (default 24 / pin 18)")
+    p.add_argument("--rst", type=int, default=25, help="RST GPIO (default 25 / pin 22)")
+    p.add_argument("--hold", type=float, default=10.0,
+                   help="seconds to leave the icon on screen (default 10)")
+    args = p.parse_args()
+
+    try:
+        serial = spi(port=args.port, device=args.device,
+                     gpio_DC=args.dc, gpio_RST=args.rst)
+        device = ssd1306(serial, width=128, height=64)
+    except Exception as e:
+        print(f"Could not open the display: {e}")
+        print("Check `ls /dev/spidev*`, wiring, and that SPI is enabled.")
+        sys.exit(1)
+
+    icon = shrimp_image()
+    frame = Image.new("1", (device.width, device.height))
+    x = (device.width - icon.width) // 2
+    y = (device.height - icon.height) // 2
+    frame.paste(icon, (x, y))
+    device.display(frame)
+    print(f"Shrimp on SPI {args.port}.{args.device}. Holding {args.hold}s... 🦐")
+    time.sleep(args.hold)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/oled-test/oled_test.py
+++ b/tools/oled-test/oled_test.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Minimal smoke test for the SSD1306 128x64 OLED over 4-wire SPI.
+
+Draws a border and "OLED OK" so you can confirm the display and wiring work.
+
+    ls /dev/spidev*          # confirm SPI is enabled (expect spidev0.0)
+    python3 oled_test.py     # uses CE0 + DC=GPIO24, RST=GPIO25 (luma defaults)
+    python3 oled_test.py --device 1 --hold 8
+"""
+import argparse
+import sys
+import time
+
+from luma.core.interface.serial import spi
+from luma.core.render import canvas
+from luma.oled.device import ssd1306
+
+
+def main():
+    p = argparse.ArgumentParser(description="Smoke test an SPI SSD1306 OLED.")
+    p.add_argument("--port", type=int, default=0, help="SPI bus (default 0)")
+    p.add_argument("--device", type=int, default=0,
+                   help="SPI chip-select: 0=CE0 (pin 24), 1=CE1 (pin 26). Default 0.")
+    p.add_argument("--dc", type=int, default=24, help="DC GPIO (default 24 / pin 18)")
+    p.add_argument("--rst", type=int, default=25, help="RST GPIO (default 25 / pin 22)")
+    p.add_argument("--hold", type=float, default=5.0,
+                   help="seconds to leave the pattern on screen (default 5)")
+    args = p.parse_args()
+
+    try:
+        serial = spi(port=args.port, device=args.device,
+                     gpio_DC=args.dc, gpio_RST=args.rst)
+        device = ssd1306(serial, width=128, height=64)
+    except Exception as e:
+        print(f"Could not open the display: {e}")
+        print("Check `ls /dev/spidev*`, wiring, and that SPI is enabled.")
+        sys.exit(1)
+
+    with canvas(device) as draw:
+        draw.rectangle(device.bounding_box, outline="white")
+        draw.text((6, 8), "OLED OK", fill="white")
+        draw.text((6, 26), f"SPI {args.port}.{args.device}", fill="white")
+        draw.text((6, 44), f"{device.width}x{device.height}", fill="white")
+    print(f"Drew test pattern on SPI {args.port}.{args.device}. "
+          f"Holding {args.hold}s...")
+    time.sleep(args.hold)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

The Phase 1 SSD1306 OLEDs are **4-wire SPI** boards, not I2C. SPI devices never appear on the I2C bus, so the image's I2C enablement and the `i2cdetect` first-boot docs were dead ends — confirmed on hardware (empty `i2cdetect`, displays driven successfully over SPI once SPI was enabled and `luma.oled` + `rpi-lgpio` were installed).

## What

- **BOM**: mark the OLED as 4-wire SPI (and re-align the Phase 1 table).
- **Image — SPI instead of I2C**:
  - `01-run.sh` now runs `raspi-config nonint do_spi 0` (displays land at `/dev/spidev0.0`/`0.1`).
  - `00-packages` drops `i2c-tools`; adds the SPI/OLED Python stack from apt (`python3-pil`, `python3-spidev`, `python3-rpi-lgpio`) plus `python3-venv`, so the heavy/compiled deps are prebuilt — no toolchain in the image.
  - New `04-run.sh` builds a `--system-site-packages` venv at `/opt/little-internet/venv` and `pip install`s `luma.oled` on top. The pip step is **best-effort** (`|| echo WARNING`) so a network hiccup can't break a release build.
- **Docs**: `image/README.md` first-boot check now points at `ls /dev/spidev*` and the pre-baked venv; stage tree updated (also documents the previously-undocumented `03-run.sh`).
- **`tools/oled-test/`**: `oled_test.py` (smoke test) and `oled_shrimp.py` (Phosphor shrimp icon, embedded 1-bit bitmap — no SVG/network needed on the Pi), plus a README covering wiring, setup, and the cold-solder-joint troubleshooting that this actually turned out to be.

## Verification

- Scripts compile; the embedded shrimp bitmap round-trips to a clean 512-byte 1-bit image.
- The OLED hardware itself is confirmed working over SPI with this exact toolchain.
- ⚠️ **Not yet validated in a full pi-gen build** — the apt package names (esp. `python3-rpi-lgpio`) and the `luma.oled` pip resolution should be confirmed green in CI before tagging **v0.4.0**. The pip step is non-fatal by design, but a missing apt package *would* fail the build, so watch the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)