### PR TITLE
OLED I2C support and shrimp test

### DIFF
--- a/BOM.md
+++ b/BOM.md
@@ -3,7 +3,7 @@
 Every part needed to build the little internet, organized by phase. Each phase
 builds on the one before it.
 
-## Phase 1: a network (~$198)
+## Phase 1: a network (~$180)
 
 | Item                                                                    | Qty | Unit  | Subtotal  | Vendor                   |
 | ----------------------------------------------------------------------- | --- | ----- | --------- | ------------------------ |
@@ -12,11 +12,11 @@ builds on the one before it.
 | SanDisk Ultra 16GB microSD, A1-rated                                    | 3   | $12   | $36       | Amazon (sold by SanDisk) |
 | Official Raspberry Pi 12.5W micro-USB PSU                               | 2   | $8    | $16       | Adafruit / PiShop        |
 | Monoprice SlimRun Cat6A 1ft (single color)                              | 5   | $2.50 | $12       | Monoprice                |
-| Adafruit SSD1306 128×64 OLED, 0.96" (bare breakout, requires soldering) | 2   | $15   | $30       | Adafruit                 |
+| ELEGOO SSD1306 128×64 OLED, 0.96" I2C (4-pin, 3-pack, no soldering)     | 1   | $12   | $12       | Amazon (sold by ELEGOO)  |
 | Female-to-female jumper wires (40-pack)                                 | 1   | $4    | $4        | Adafruit / Amazon        |
-| **Phase 1 total**                                                       |     |       | **~$198** |                          |
+| **Phase 1 total**                                                       |     |       | **~$180** |                          |
 
-## Phase 2: two networks (+~$112, running ~$310)
+## Phase 2: two networks (+~$112, running ~$292)
 
 | Item                                                                              | Qty | Unit  | Subtotal  | Vendor                   |
 | --------------------------------------------------------------------------------- | --- | ----- | --------- | ------------------------ |
@@ -27,9 +27,9 @@ builds on the one before it.
 | SanDisk Ultra 16GB microSD, A1-rated                                              | 1   | $12   | $12       | Amazon (sold by SanDisk) |
 | Monoprice SlimRun Cat6A 1ft (second color)                                        | 5   | $2.50 | $12       | Monoprice                |
 | **Phase 2 added**                                                                 |     |       | **~$112** |                          |
-| **Running total**                                                                 |     |       | **~$310** |                          |
+| **Running total**                                                                 |     |       | **~$292** |                          |
 
-## Phase 3: the little internet (+~$148, running ~$458)
+## Phase 3: the little internet (+~$148, running ~$440)
 
 | Item                                                  | Qty | Unit  | Subtotal  | Vendor                   |
 | ----------------------------------------------------- | --- | ----- | --------- | ------------------------ |
@@ -39,4 +39,4 @@ builds on the one before it.
 | SanDisk Ultra 16GB microSD, A1-rated                  | 2   | $12   | $24       | Amazon (sold by SanDisk) |
 | Monoprice SlimRun Cat6A 1ft (third color)             | 3   | $2.50 | $8        | Monoprice                |
 | **Phase 3 added**                                     |     |       | **~$148** |                          |
-| **Running total**                                     |     |       | **~$458** |                          |
+| **Running total**                                     |     |       | **~$440** |                          |

--- a/image/README.md
+++ b/image/README.md
@@ -130,7 +130,8 @@ image/
     │   ├── 01-run.sh             Enables the I2C bus for the SSD1306 OLED displays + adds the user to the i2c group.
     │   ├── 02-run.sh             Installs a pre-provisioned Wi-Fi connection, if one was generated.
     │   ├── 03-run.sh             Lets the user run tshark unprivileged and sets COLORTERM for colored output over SSH.
-    │   └── 04-run.sh             Builds /opt/little-internet/venv with luma.oled to drive the OLED displays.
+    │   ├── 04-run.sh             Builds /opt/little-internet/venv with luma.oled to drive the OLED displays.
+    │   └── 05-run.sh             Installs the OLED test scripts into ~/oled-test (staged from tools/oled-test by build.sh).
     ├── 01-firstboot-config/      First-boot hostname + Wi-Fi provisioner for flashed (released) images.
     │   ├── 00-run.sh             Installs the provisioner script, service, and boot-partition template.
     │   └── files/                The script, systemd unit, and little-internet.txt.example.

--- a/image/README.md
+++ b/image/README.md
@@ -127,8 +127,10 @@ image/
     ├── 00-net-tools/
     │   ├── 00-debconf            Preseeds iperf3 to not autostart (keeps the build non-interactive).
     │   ├── 00-packages           apt packages to install (capture, ARP, VLAN, I2C…).
-    │   ├── 01-run.sh             Enables the I2C bus for the SSD1306 OLED displays.
-    │   └── 02-run.sh             Installs a pre-provisioned Wi-Fi connection, if one was generated.
+    │   ├── 01-run.sh             Enables the I2C bus for the SSD1306 OLED displays + adds the user to the i2c group.
+    │   ├── 02-run.sh             Installs a pre-provisioned Wi-Fi connection, if one was generated.
+    │   ├── 03-run.sh             Lets the user run tshark unprivileged and sets COLORTERM for colored output over SSH.
+    │   └── 04-run.sh             Builds /opt/little-internet/venv with luma.oled to drive the OLED displays.
     ├── 01-firstboot-config/      First-boot hostname + Wi-Fi provisioner for flashed (released) images.
     │   ├── 00-run.sh             Installs the provisioner script, service, and boot-partition template.
     │   └── files/                The script, systemd unit, and little-internet.txt.example.

--- a/image/build.sh
+++ b/image/build.sh
@@ -139,6 +139,15 @@ method=auto
 EOF
 fi
 
+# 3c. Stage the OLED test scripts so 00-net-tools/05-run.sh can drop them into
+#     the first user's home. tools/oled-test is the single source of truth (it's
+#     outside image/, so it isn't part of the stage copy at step 3); we stage
+#     only the runnable scripts, not the dev README/.gitignore.
+oled_src="${HERE}/../tools/oled-test"
+oled_files="${PIGEN_DIR}/${STAGE_NAME}/00-net-tools/files/oled-test"
+mkdir -p "${oled_files}"
+cp "${oled_src}/oled_test.py" "${oled_src}/oled_shrimp.py" "${oled_files}/"
+
 # 4. Only export our final image, not the intermediate Lite image.
 touch "${PIGEN_DIR}/stage2/SKIP_IMAGES"
 

--- a/image/stage-little-internet/00-net-tools/00-packages
+++ b/image/stage-little-internet/00-net-tools/00-packages
@@ -20,7 +20,11 @@ bridge-utils
 # RPi OS Lite doesn't ship the nft binary by default.
 nftables
 
-# I2C tooling + Python for the SSD1306 OLED displays in the Phase 1 BOM
+# I2C tooling + Python for the SSD1306 I2C OLED displays in the Phase 1 BOM.
+# Pillow comes prebuilt from apt (no toolchain in the image); the pure-python
+# luma.oled library is layered on top via pip in 04-run.sh.
 i2c-tools
 python3
+python3-venv
 python3-pip
+python3-pil

--- a/image/stage-little-internet/00-net-tools/01-run.sh
+++ b/image/stage-little-internet/00-net-tools/01-run.sh
@@ -1,7 +1,14 @@
 #!/bin/bash -e
 
-# Enable the I2C bus so the SSD1306 OLED displays from the Phase 1 BOM work
-# out of the box. (raspi-config's "do_i2c 0" means *enable*.)
+# Enable the I2C bus so the 4-pin SSD1306 OLED displays from the Phase 1 BOM
+# work out of the box. They show up on /dev/i2c-1 (usually at address 0x3c).
+# (raspi-config's "do_i2c 0" means *enable*.)
 on_chroot << 'EOF'
 raspi-config nonint do_i2c 0
+EOF
+
+# Let the default user reach the I2C bus without sudo. Use an *unquoted*
+# heredoc so ${FIRST_USER_NAME} expands on the host before running in the chroot.
+on_chroot << EOF
+adduser ${FIRST_USER_NAME} i2c
 EOF

--- a/image/stage-little-internet/00-net-tools/04-run.sh
+++ b/image/stage-little-internet/00-net-tools/04-run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+# Build a virtualenv with the OLED display library so the SSD1306 I2C panels in
+# the Phase 1 BOM work out of the box. luma.oled isn't packaged in apt, so it's
+# installed via pip; Pillow comes from apt (see 00-packages) and is exposed
+# through --system-site-packages, so no compiler runs inside the image. For I2C
+# luma pulls in the pure-python smbus2, so there's nothing else to build.
+#
+# The pip step needs network and is best-effort: if it fails the image still
+# builds with I2C enabled and Pillow present, and luma can be added later with
+# `sudo /opt/little-internet/venv/bin/pip install luma.oled`.
+on_chroot << 'EOF'
+python3 -m venv --system-site-packages /opt/little-internet/venv
+/opt/little-internet/venv/bin/pip install --no-input luma.oled \
+	|| echo "WARNING: luma.oled pip install failed; install it on-device later."
+EOF

--- a/image/stage-little-internet/00-net-tools/05-run.sh
+++ b/image/stage-little-internet/00-net-tools/05-run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+# Install the OLED test scripts into the first user's home so they can be run
+# straight off a freshly flashed card, against the venv built in 04-run.sh:
+#   /opt/little-internet/venv/bin/python3 ~/oled-test/oled_test.py
+#   /opt/little-internet/venv/bin/python3 ~/oled-test/oled_shrimp.py
+#
+# The scripts are staged into files/oled-test by build.sh from tools/oled-test
+# (the single source of truth). Copy them in on the host, then fix ownership
+# inside the chroot where ${FIRST_USER_NAME} resolves to its uid/gid.
+install -d -m 755 "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/oled-test"
+install -m 755 files/oled-test/oled_test.py files/oled-test/oled_shrimp.py \
+	"${ROOTFS_DIR}/home/${FIRST_USER_NAME}/oled-test/"
+
+on_chroot << EOF
+chown -R ${FIRST_USER_NAME}:${FIRST_USER_NAME} /home/${FIRST_USER_NAME}/oled-test
+EOF

--- a/tools/oled-test/.gitignore
+++ b/tools/oled-test/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tools/oled-test/README.md
+++ b/tools/oled-test/README.md
@@ -18,11 +18,16 @@ Quick smoke tests for the **SSD1306 128×64** OLEDs over **I2C** (4-pin modules)
 
 ## On the Pi
 
-> **On the official little-internet image** I2C is already enabled and the
-> library is pre-installed at `/opt/little-internet/venv`. Skip straight to
-> running the scripts with that interpreter:
-> `/opt/little-internet/venv/bin/python3 oled_shrimp.py`. The steps below are for
-> a stock Raspberry Pi OS where you set this up yourself.
+> **On the official little-internet image** I2C is already enabled, the library
+> is pre-installed at `/opt/little-internet/venv`, and these scripts ship in
+> `~/oled-test`. Wire it up and run, straight off a fresh flash:
+>
+> ```sh
+> /opt/little-internet/venv/bin/python3 ~/oled-test/oled_test.py
+> /opt/little-internet/venv/bin/python3 ~/oled-test/oled_shrimp.py
+> ```
+>
+> The steps below are for a stock Raspberry Pi OS where you set this up yourself.
 
 ```sh
 # 1. Enable I2C (one-time), then reboot

--- a/tools/oled-test/README.md
+++ b/tools/oled-test/README.md
@@ -1,0 +1,65 @@
+# OLED test scripts
+
+Quick smoke tests for the **SSD1306 128×64** OLEDs over **I2C** (4-pin modules).
+
+- `oled_test.py` — draws a border + "OLED OK" so you can confirm the display works.
+- `oled_shrimp.py` — shows the Phosphor [`shrimp`](https://phosphoricons.com/?q=shrimp)
+  icon. The icon is baked in as a 64×64 1-bit bitmap, so no network or SVG libs
+  are needed on the Pi.
+
+## Wiring (4-pin I2C SSD1306 → Pi 40-pin header)
+
+| OLED pin | Pi pin | GPIO        |
+|----------|--------|-------------|
+| GND      | 6      | —           |
+| VCC      | 1      | 3.3V        |
+| SCL      | 5      | GPIO3 (SCL) |
+| SDA      | 3      | GPIO2 (SDA) |
+
+## On the Pi
+
+> **On the official little-internet image** I2C is already enabled and the
+> library is pre-installed at `/opt/little-internet/venv`. Skip straight to
+> running the scripts with that interpreter:
+> `/opt/little-internet/venv/bin/python3 oled_shrimp.py`. The steps below are for
+> a stock Raspberry Pi OS where you set this up yourself.
+
+```sh
+# 1. Enable I2C (one-time), then reboot
+sudo raspi-config nonint do_i2c 0
+sudo reboot
+i2cdetect -y 1            # expect the panel at 0x3c (sometimes 0x3d)
+
+# 2. Install the OLED library. Pi OS Bookworm blocks system-wide pip, so use a
+#    venv. luma.oled pulls in smbus2 (pure-python I2C), so no GPIO backend or
+#    compiler is needed for I2C panels.
+python3 -m venv ~/oledvenv
+~/oledvenv/bin/pip install luma.oled
+
+# 3. Run a test — IMPORTANT: use the venv's python, not the system one.
+#    `python3 oled_test.py` uses /usr/bin/python3, which lacks these packages
+#    and fails with "No module named 'luma'".
+~/oledvenv/bin/python3 oled_test.py
+~/oledvenv/bin/python3 oled_shrimp.py
+```
+
+> Quick-and-dirty alternative to the venv:
+> `sudo pip3 install luma.oled --break-system-packages` (then plain `python3` works).
+
+## Nothing on the screen?
+
+- Run `i2cdetect -y 1` first. **No address shown** = a wiring/power problem
+  (these are often hand-soldered bare breakouts — a cold solder joint or
+  swapped SDA/SCL is the usual cause). Power off and continuity-test each joint
+  (OLED pad ↔ Pi header pin) with a multimeter on the Ω/200 range: near-0 = good,
+  `1`/overrange = open.
+- **Address shows at 0x3d, not 0x3c?** Pass `--address 0x3d`.
+- **Image garbled or offset?** Some 128×64 modules are **SH1106**, not SSD1306.
+  Pass `--controller sh1106`.
+
+## Options (both scripts)
+
+- `--port N` — I2C bus (default `1` / `/dev/i2c-1`).
+- `--address 0xNN` — I2C address (default `0x3c`).
+- `--controller ssd1306|sh1106` — display controller (default `ssd1306`).
+- `--hold SECONDS` — how long to leave the image up.

--- a/tools/oled-test/oled_shrimp.py
+++ b/tools/oled-test/oled_shrimp.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Show the Phosphor 'shrimp' icon on the SSD1306 128x64 OLED over I2C.
+
+The icon is embedded as a 64x64 1-bit bitmap (rendered from the Phosphor
+regular 'shrimp' SVG, https://phosphoricons.com/?q=shrimp), so this script
+needs no network access or SVG libraries on the Pi.
+
+    python3 oled_shrimp.py                 # bus 1, address 0x3C (the common case)
+    python3 oled_shrimp.py --address 0x3D  # some modules strap to 0x3D
+    python3 oled_shrimp.py --controller sh1106
+"""
+import argparse
+import base64
+import sys
+import time
+
+from PIL import Image
+
+from luma.core.interface.serial import i2c
+from luma.oled.device import sh1106, ssd1306
+
+# 64x64, 1-bit, MSB-first packed (PIL mode "1"). Phosphor "shrimp" (regular).
+SHRIMP_64_B64 = (
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAADwAAAAAAAAAPA"
+    "AAAAAAAAA+AAAAAAAAAB////8AAAAAH////4AAAAAP////wAAAAAP////gAAAAAAAAAfAA"
+    "AAAAAAAA8AAAAAAAAADwAAAAAAAAAPAAAAAAAAAA8AAAAAAAAAHwAAAP/////+AAAP////"
+    "//wAAD//////+AAAf//////wAAH/A8AAAPAAA/gDwAAA8AAH4APAAAHgAA/AA8AAAeAAD4"
+    "ADweAB4AAfAAPD8APgAD4AA8PwA8AAPAADw/AHwAB8AAPD8A+AAHwAA8HgHwAAfwADwAA/"
+    "AAD/wAPAAH4AAP/wA8AB/AAA9/4DwA/4AADx/4f//+AAAPB/7///wAAA8B////8AAADwA/"
+    "//8AAAAPAA/AAAAAAA8AB4AAAAAAB4AHgAAAAAAHgAeAAAAAAAeAH4AAAAAAB8A/wAAAAA"
+    "ADwH///+AAAAPh////8AAAAfP4///wAAAA/+B//+AAAAD/wDwAAAAAAH+APAAAAAAAP4A8"
+    "AAAAAAAf8DwAAAAAAAf///4AAAAAA////wAAAAAA////AAAAAAAP//4AAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+)
+
+
+def shrimp_image():
+    raw = base64.b64decode(SHRIMP_64_B64)
+    return Image.frombytes("1", (64, 64), raw)
+
+
+def main():
+    p = argparse.ArgumentParser(description="Show the Phosphor shrimp on an I2C OLED.")
+    p.add_argument("--port", type=int, default=1,
+                   help="I2C bus (default 1 / /dev/i2c-1)")
+    p.add_argument("--address", type=lambda x: int(x, 0), default=0x3C,
+                   help="I2C address (default 0x3C; some modules use 0x3D)")
+    p.add_argument("--controller", choices=("ssd1306", "sh1106"), default="ssd1306",
+                   help="display controller (default ssd1306; try sh1106 if garbled)")
+    p.add_argument("--hold", type=float, default=10.0,
+                   help="seconds to leave the icon on screen (default 10)")
+    args = p.parse_args()
+
+    try:
+        serial = i2c(port=args.port, address=args.address)
+        controller = sh1106 if args.controller == "sh1106" else ssd1306
+        device = controller(serial, width=128, height=64)
+    except Exception as e:
+        print(f"Could not open the display: {e}")
+        print(f"Check `i2cdetect -y {args.port}` for the address, the wiring, "
+              "and that I2C is enabled.")
+        sys.exit(1)
+
+    icon = shrimp_image()
+    frame = Image.new("1", (device.width, device.height))
+    x = (device.width - icon.width) // 2
+    y = (device.height - icon.height) // 2
+    frame.paste(icon, (x, y))
+    device.display(frame)
+    print(f"Shrimp on I2C {args.port} @ {hex(args.address)}. "
+          f"Holding {args.hold}s... 🦐")
+    time.sleep(args.hold)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/oled-test/oled_test.py
+++ b/tools/oled-test/oled_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Minimal smoke test for the SSD1306 128x64 OLED over I2C.
+
+Draws a border and "OLED OK" so you can confirm the display and wiring work.
+
+    i2cdetect -y 1          # confirm the panel shows up (usually at 0x3c)
+    python3 oled_test.py    # bus 1, address 0x3C
+    python3 oled_test.py --address 0x3d --hold 8
+"""
+import argparse
+import sys
+import time
+
+from luma.core.interface.serial import i2c
+from luma.core.render import canvas
+from luma.oled.device import sh1106, ssd1306
+
+
+def main():
+    p = argparse.ArgumentParser(description="Smoke test an I2C SSD1306 OLED.")
+    p.add_argument("--port", type=int, default=1,
+                   help="I2C bus (default 1 / /dev/i2c-1)")
+    p.add_argument("--address", type=lambda x: int(x, 0), default=0x3C,
+                   help="I2C address (default 0x3C; some modules use 0x3D)")
+    p.add_argument("--controller", choices=("ssd1306", "sh1106"), default="ssd1306",
+                   help="display controller (default ssd1306; try sh1106 if garbled)")
+    p.add_argument("--hold", type=float, default=5.0,
+                   help="seconds to leave the pattern on screen (default 5)")
+    args = p.parse_args()
+
+    try:
+        serial = i2c(port=args.port, address=args.address)
+        controller = sh1106 if args.controller == "sh1106" else ssd1306
+        device = controller(serial, width=128, height=64)
+    except Exception as e:
+        print(f"Could not open the display: {e}")
+        print(f"Check `i2cdetect -y {args.port}` for the address, the wiring, "
+              "and that I2C is enabled.")
+        sys.exit(1)
+
+    with canvas(device) as draw:
+        draw.rectangle(device.bounding_box, outline="white")
+        draw.text((6, 8), "OLED OK", fill="white")
+        draw.text((6, 26), f"I2C {args.port} @ {hex(args.address)}", fill="white")
+        draw.text((6, 44), f"{device.width}x{device.height}", fill="white")
+    print(f"Drew test pattern on I2C {args.port} @ {hex(args.address)}. "
+          f"Holding {args.hold}s...")
+    time.sleep(args.hold)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Enables I2C and bakes `luma.oled` into the image so the Phase 1 SSD1306 OLEDs (4-pin ELEGOO I2C modules) work out of the box. Adds `tools/oled-test/` smoke-test + Phosphor shrimp scripts. Validated on hardware (SSD1306 @ 0x3c). BOM/README updated to I2C.

Toward a v0.4.0 image release.