### PR TITLE
Show hostname, MAC, and IPs on the OLED from boot

### DIFF
--- a/image/README.md
+++ b/image/README.md
@@ -91,6 +91,12 @@ file in place so you can fix it and reboot.
   with no prompt.
 - Confirm the networking tools are present: `which tcpdump tshark arping`.
 - Check the I2C bus (for the OLED): `i2cdetect -y 1`.
+- If an OLED is wired up, it shows the node's identity from boot — hostname in
+  the yellow strip, eth0's MAC and each interface's IPv4 in the blue area — so
+  a rack of identical Pis is tellable-apart at a glance (see
+  [`tools/status-oled`](../tools/status-oled/README.md)). The on-demand OLED
+  scripts (`~/oled-test`, `~/arp-oled`) borrow the panel while they run and the
+  status display resumes when they exit.
 - Wi-Fi is management-only by design: you can SSH in and the node reaches the
   internet, but two nodes **can't reach each other over Wi-Fi**. The lessons run
   on a wired link instead. So if a second node seems unreachable _from the first
@@ -132,7 +138,9 @@ image/
     │   ├── 03-run.sh             Lets the user run tshark unprivileged, pre-creates ~/cap, and sets COLORTERM for colored output over SSH.
     │   ├── 04-run.sh             Builds /opt/little-internet/venv with luma.oled to drive the OLED displays.
     │   ├── 05-run.sh             Installs the OLED test scripts into ~/oled-test (staged from tools/oled-test by build.sh).
-    │   └── files/                eth-dhcp.nmconnection — the eth0 DHCP baseline keyfile (build.sh also stages oled-test/ here).
+    │   ├── 06-run.sh             Installs the on-demand ARP-state OLED viewer into ~/arp-oled (staged from tools/arp-oled by build.sh).
+    │   ├── 07-run.sh             Installs + enables the boot-time OLED status display, little-internet-oled.service (staged from tools/status-oled by build.sh).
+    │   └── files/                eth-dhcp.nmconnection + little-internet-oled.service (build.sh also stages oled-test/, arp-oled/, and status-oled/ here).
     ├── 01-firstboot-config/      First-boot hostname + Wi-Fi provisioner for flashed (released) images.
     │   ├── 00-run.sh             Installs the provisioner script, service, and boot-partition template.
     │   └── files/                The script, systemd unit, and little-internet.txt.example.

--- a/image/build.sh
+++ b/image/build.sh
@@ -154,6 +154,13 @@ arp_files="${PIGEN_DIR}/${STAGE_NAME}/00-net-tools/files/arp-oled"
 mkdir -p "${arp_files}"
 cp "${HERE}/../tools/arp-oled/arp_oled.py" "${arp_files}/"
 
+# 3e. Stage the boot-time OLED status display (tools/status-oled is its source
+#     of truth); 00-net-tools/07-run.sh installs it under /opt/little-internet
+#     and enables it as a systemd service.
+status_files="${PIGEN_DIR}/${STAGE_NAME}/00-net-tools/files/status-oled"
+mkdir -p "${status_files}"
+cp "${HERE}/../tools/status-oled/status_oled.py" "${status_files}/"
+
 # 4. Only export our final image, not the intermediate Lite image.
 touch "${PIGEN_DIR}/stage2/SKIP_IMAGES"
 

--- a/image/stage-little-internet/00-net-tools/06-run.sh
+++ b/image/stage-little-internet/00-net-tools/06-run.sh
@@ -8,8 +8,10 @@
 #
 # Run it by hand against the venv built in 04-run.sh (no sudo: reading the
 # neighbour cache is unprivileged and the first user is already in the i2c
-# group). It deliberately is NOT a boot service — that would permanently claim
-# the OLED and fight the oled-test smoke scripts over the one I2C panel:
+# group). It deliberately is NOT a boot service — the panel's boot-time
+# resident is the status display (07-run.sh). While this script runs it pauses
+# that display via the claim file described in little-internet-oled.service,
+# and hands the panel back on exit:
 #   /opt/little-internet/venv/bin/python3 ~/arp-oled/arp_oled.py
 #
 # Staged into files/arp-oled by build.sh from tools/arp-oled (source of truth);

--- a/image/stage-little-internet/00-net-tools/07-run.sh
+++ b/image/stage-little-internet/00-net-tools/07-run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+# Install the boot-time OLED status display: hostname in the yellow strip,
+# eth0's MAC and each interface's IPv4 in the blue body, painted from boot so
+# a rack of identical Pis is tellable-apart at a glance. Runs as a systemd
+# service (little-internet-oled.service) against the venv built in 04-run.sh.
+#
+# The script lives in /opt/little-internet (not the user's home) because a
+# root service shouldn't execute user-editable files. The on-demand scripts
+# installed by 05-/06-run.sh share the panel with it through the claim file
+# described in the service unit.
+#
+# Staged into files/status-oled by build.sh from tools/status-oled (source of
+# truth).
+install -d -m 755 "${ROOTFS_DIR}/opt/little-internet/status-oled"
+install -m 755 files/status-oled/status_oled.py \
+	"${ROOTFS_DIR}/opt/little-internet/status-oled/"
+
+install -m 644 files/little-internet-oled.service \
+	"${ROOTFS_DIR}/etc/systemd/system/little-internet-oled.service"
+
+on_chroot << 'EOF'
+systemctl enable little-internet-oled.service
+EOF

--- a/image/stage-little-internet/00-net-tools/files/little-internet-oled.service
+++ b/image/stage-little-internet/00-net-tools/files/little-internet-oled.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Show hostname, MAC, and IPv4 on the OLED (little-internet)
+# The boot-time resident of the panel: with a rack of identical Pis, the OLED
+# is what tells you which node is which. Ordered after the first-boot
+# provisioner so a hostname from little-internet.txt is already set when the
+# first frame paints. No network dependency — the script polls, so addresses
+# appear as DHCP hands them out.
+After=local-fs.target little-internet.service
+
+[Service]
+Type=simple
+# Unbuffered stdout so the script's log lines reach the journal as they
+# happen, not when the buffer fills.
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/opt/little-internet/venv/bin/python3 /opt/little-internet/status-oled/status_oled.py
+Restart=on-failure
+RestartSec=5
+# /run/little-internet is the handoff point for the one panel: on-demand OLED
+# scripts (~/arp-oled, ~/oled-test) create oled.claim there to pause this
+# display and remove it to resume. Group i2c + 0775 lets the unprivileged lab
+# user (already in i2c for the bus itself) create and remove that file.
+Group=i2c
+RuntimeDirectory=little-internet
+RuntimeDirectoryMode=0775
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/arp-oled/README.md
+++ b/tools/arp-oled/README.md
@@ -15,8 +15,10 @@ the cache is unprivileged, and the `pi` user is already in the `i2c` group):
 
 By default it watches the other half of the `10.10.0.x` pair (on `.1` it watches
 `.2`, and vice versa); override with `--peer`. Ctrl-C clears the panel and exits.
-It's a script, not a service, so it won't fight the `oled-test` scripts for the
-display.
+On the image the panel normally shows the boot-time
+[status display](../status-oled/README.md) (hostname/MAC/IP); this script pauses
+it while it runs — via `/run/little-internet/oled.claim`, no sudo needed — and
+the status display repaints when this exits.
 
 ## Drive the state machine
 

--- a/tools/arp-oled/arp_oled.py
+++ b/tools/arp-oled/arp_oled.py
@@ -17,6 +17,10 @@ machine yourself from another shell and watch the panel follow along:
 The peer defaults to the other half of the 10.10.0.1 <-> 10.10.0.2 lab pair
 (auto-picked from this node's own address), or pass --peer.
 
+On the little-internet image the panel normally shows the boot-time status
+display (hostname/MAC/IP); this script pauses it via a claim file while it
+runs and the status display resumes when this exits.
+
     /opt/little-internet/venv/bin/python3 arp_oled.py
     arp_oled.py --peer 10.10.0.2 --interval 0.5
     arp_oled.py --address 0x3d --controller sh1106
@@ -25,6 +29,7 @@ The peer defaults to the other half of the 10.10.0.1 <-> 10.10.0.2 lab pair
 import argparse
 import json
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -38,6 +43,33 @@ from luma.oled.device import sh1106, ssd1306
 # image and service work unchanged on both cards.
 PAIR = {"10.10.0.1": "10.10.0.2", "10.10.0.2": "10.10.0.1"}
 DEFAULT_PEER = "10.10.0.2"
+
+# The boot-time status display (little-internet-oled.service on the image)
+# owns the panel; it pauses while this claim file exists and resumes when it's
+# removed. The claim directory is that service's RuntimeDirectory (root:i2c,
+# 0775), so no sudo is needed. On systems without the service, claiming just
+# fails quietly — there's nothing to pause.
+CLAIM_FILE = "/run/little-internet/oled.claim"
+
+
+def claim_panel():
+    """Pause the boot status display; True if the claim file was written."""
+    try:
+        with open(CLAIM_FILE, "w") as fh:
+            fh.write(f"{os.getpid()}\n")
+    except OSError:
+        return False
+    # Let an in-flight status frame land before we paint over it.
+    time.sleep(0.5)
+    return True
+
+
+def release_panel(claimed):
+    if claimed:
+        try:
+            os.remove(CLAIM_FILE)
+        except OSError:
+            pass
 
 # NUD states worth a one-glance read. Anything else is shown verbatim.
 KNOWN_STATES = {
@@ -228,6 +260,10 @@ def main():
         print("Requested font unavailable; using the built-in bitmap font.")
 
     print(f"Watching ARP state for {peer} (poll {args.interval}s). Ctrl-C to stop.")
+    # Python dies on SIGTERM without running `finally`, which would strand the
+    # claim file and leave the status display paused; exit cleanly instead.
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+    claimed = claim_panel()
     beat = False
     try:
         while True:
@@ -238,6 +274,9 @@ def main():
     except KeyboardInterrupt:
         device.clear()
         print("\nDone.")
+    finally:
+        # Hand the panel back: the status display repaints within a second.
+        release_panel(claimed)
 
 
 if __name__ == "__main__":

--- a/tools/oled-test/README.md
+++ b/tools/oled-test/README.md
@@ -27,6 +27,11 @@ Quick smoke tests for the **SSD1306 128×64** OLEDs over **I2C** (4-pin modules)
 > /opt/little-internet/venv/bin/python3 ~/oled-test/oled_shrimp.py
 > ```
 >
+> On the image the panel is normally driven by the boot-time
+> [status display](../status-oled/README.md) (hostname/MAC/IP). These scripts
+> pause it while they run and it repaints when they exit, so a working panel
+> already showing status is itself a passing smoke test.
+>
 > The steps below are for a stock Raspberry Pi OS where you set this up yourself.
 
 ```sh

--- a/tools/oled-test/oled_shrimp.py
+++ b/tools/oled-test/oled_shrimp.py
@@ -11,6 +11,8 @@ needs no network access or SVG libraries on the Pi.
 """
 import argparse
 import base64
+import os
+import signal
 import sys
 import time
 
@@ -18,6 +20,33 @@ from PIL import Image
 
 from luma.core.interface.serial import i2c
 from luma.oled.device import sh1106, ssd1306
+
+# The boot-time status display (little-internet-oled.service on the image)
+# owns the panel; it pauses while this claim file exists and resumes when it's
+# removed. The claim directory is that service's RuntimeDirectory (root:i2c,
+# 0775), so no sudo is needed. On systems without the service, claiming just
+# fails quietly — there's nothing to pause.
+CLAIM_FILE = "/run/little-internet/oled.claim"
+
+
+def claim_panel():
+    """Pause the boot status display; True if the claim file was written."""
+    try:
+        with open(CLAIM_FILE, "w") as fh:
+            fh.write(f"{os.getpid()}\n")
+    except OSError:
+        return False
+    # Let an in-flight status frame land before we paint over it.
+    time.sleep(0.5)
+    return True
+
+
+def release_panel(claimed):
+    if claimed:
+        try:
+            os.remove(CLAIM_FILE)
+        except OSError:
+            pass
 
 # 64x64, 1-bit, MSB-first packed (PIL mode "1"). Phosphor "shrimp" (regular).
 SHRIMP_64_B64 = (
@@ -66,10 +95,17 @@ def main():
     x = (device.width - icon.width) // 2
     y = (device.height - icon.height) // 2
     frame.paste(icon, (x, y))
-    device.display(frame)
-    print(f"Shrimp on I2C {args.port} @ {hex(args.address)}. "
-          f"Holding {args.hold}s... 🦐")
-    time.sleep(args.hold)
+    # Python dies on SIGTERM without running `finally`, which would strand the
+    # claim file and leave the status display paused; exit cleanly instead.
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+    claimed = claim_panel()
+    try:
+        device.display(frame)
+        print(f"Shrimp on I2C {args.port} @ {hex(args.address)}. "
+              f"Holding {args.hold}s... 🦐")
+        time.sleep(args.hold)
+    finally:
+        release_panel(claimed)
     print("Done.")
 
 

--- a/tools/oled-test/oled_test.py
+++ b/tools/oled-test/oled_test.py
@@ -8,12 +8,41 @@ Draws a border and "OLED OK" so you can confirm the display and wiring work.
     python3 oled_test.py --address 0x3d --hold 8
 """
 import argparse
+import os
+import signal
 import sys
 import time
 
 from luma.core.interface.serial import i2c
 from luma.core.render import canvas
 from luma.oled.device import sh1106, ssd1306
+
+# The boot-time status display (little-internet-oled.service on the image)
+# owns the panel; it pauses while this claim file exists and resumes when it's
+# removed. The claim directory is that service's RuntimeDirectory (root:i2c,
+# 0775), so no sudo is needed. On systems without the service, claiming just
+# fails quietly — there's nothing to pause.
+CLAIM_FILE = "/run/little-internet/oled.claim"
+
+
+def claim_panel():
+    """Pause the boot status display; True if the claim file was written."""
+    try:
+        with open(CLAIM_FILE, "w") as fh:
+            fh.write(f"{os.getpid()}\n")
+    except OSError:
+        return False
+    # Let an in-flight status frame land before we paint over it.
+    time.sleep(0.5)
+    return True
+
+
+def release_panel(claimed):
+    if claimed:
+        try:
+            os.remove(CLAIM_FILE)
+        except OSError:
+            pass
 
 
 def main():
@@ -38,14 +67,21 @@ def main():
               "and that I2C is enabled.")
         sys.exit(1)
 
-    with canvas(device) as draw:
-        draw.rectangle(device.bounding_box, outline="white")
-        draw.text((6, 8), "OLED OK", fill="white")
-        draw.text((6, 26), f"I2C {args.port} @ {hex(args.address)}", fill="white")
-        draw.text((6, 44), f"{device.width}x{device.height}", fill="white")
-    print(f"Drew test pattern on I2C {args.port} @ {hex(args.address)}. "
-          f"Holding {args.hold}s...")
-    time.sleep(args.hold)
+    # Python dies on SIGTERM without running `finally`, which would strand the
+    # claim file and leave the status display paused; exit cleanly instead.
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+    claimed = claim_panel()
+    try:
+        with canvas(device) as draw:
+            draw.rectangle(device.bounding_box, outline="white")
+            draw.text((6, 8), "OLED OK", fill="white")
+            draw.text((6, 26), f"I2C {args.port} @ {hex(args.address)}", fill="white")
+            draw.text((6, 44), f"{device.width}x{device.height}", fill="white")
+        print(f"Drew test pattern on I2C {args.port} @ {hex(args.address)}. "
+              f"Holding {args.hold}s...")
+        time.sleep(args.hold)
+    finally:
+        release_panel(claimed)
     print("Done.")
 
 

--- a/tools/status-oled/README.md
+++ b/tools/status-oled/README.md
@@ -1,0 +1,58 @@
+# Status OLED
+
+`status_oled.py` paints the node's identity on the SSD1306 from boot: the
+hostname in the yellow strip, and eth0's MAC plus the current IPv4 address of
+each interface in the blue body. With a rack of identical Pis, the panel is
+what tells you which one is which — and whose ARP entry you're looking at.
+
+```
+pi-foo-01              ← yellow strip: hostname
+──────────────────
+d8:3a:dd:4e:aa:10      ← eth0's MAC (the node's layer-2 identity)
+eth0 10.10.0.1         ← the lab wire
+wlan0 192.168.1.77     ← your SSH path
+```
+
+It refreshes once a second, so a DHCP lease landing or a cable pull shows up
+live: an interface reads `(down)` with no cable, `(no IPv4)` while it waits
+for an address — the difference lesson 00 is built on.
+
+## On the image
+
+The little-internet image runs it as a boot service, so a powered node always
+shows who it is:
+
+```sh
+systemctl status little-internet-oled    # the service driving the panel
+sudo systemctl stop little-internet-oled # blank the panel until next boot
+```
+
+The service installs the script at `/opt/little-internet/status-oled/`.
+
+## Sharing the panel
+
+There's one panel and sometimes two things that want it. The on-demand scripts
+(`~/arp-oled`, `~/oled-test`) borrow it by creating
+`/run/little-internet/oled.claim` while they run; this display pauses while
+that file exists and resumes when the script exits and removes it. No sudo
+involved: the claim directory is group-writable by `i2c`, which the lab user
+is already in.
+
+## Options
+
+- `--interfaces IF [IF ...]`: interfaces to show, one IPv4 line each; the
+  first one's MAC is shown too (default: `eth0 wlan0`)
+- `--interval N`: seconds between refreshes (default `1.0`)
+- `--port N`: I2C bus (default `1`)
+- `--address 0xNN`: I2C address (default `0x3c`; some modules use `0x3d`)
+- `--controller ssd1306|sh1106`: try `sh1106` if the display is garbled
+- `--font PATH`: TTF (default: JetBrains Mono, then DejaVu Sans Mono, then PIL's bitmap font)
+- `--claim-file PATH`: pause while this file exists (default `/run/little-internet/oled.claim`)
+
+If no display answers on the bus, it exits 0 (a node without a panel is fine;
+the service goes quietly inactive rather than restart-looping).
+
+## Trouble
+
+Blank, garbled, or wrong address? See [`../oled-test/README.md`](../oled-test/README.md):
+same panel, same wiring.

--- a/tools/status-oled/status_oled.py
+++ b/tools/status-oled/status_oled.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Paint this node's identity — hostname, MAC, IPv4 — on the OLED.
+
+This is the boot-time resident of the panel: little-internet-oled.service
+starts it at boot so a powered node permanently shows who it is. The yellow
+strip gets the hostname; the blue body gets eth0's MAC (the node's layer-2
+identity in the lessons) and the current IPv4 address of each interface —
+eth0 (the lab wire) and wlan0 (your SSH path). Everything refreshes once a
+second, so a DHCP lease landing or a cable pull shows up as it happens.
+
+On-demand scripts (~/arp-oled, ~/oled-test) borrow the panel by dropping a
+claim file at /run/little-internet/oled.claim; while it exists this display
+paints nothing, and when the script exits and removes it, this one resumes.
+
+Run it by hand the same way the service does:
+
+    /opt/little-internet/venv/bin/python3 status_oled.py
+    status_oled.py --address 0x3d --controller sh1106
+    status_oled.py --interfaces eth0        # lab wire only
+"""
+import argparse
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+
+from PIL import Image, ImageDraw, ImageFont
+
+from luma.core.interface.serial import i2c
+from luma.oled.device import sh1106, ssd1306
+
+# On-demand OLED scripts create this to pause us; see the module docstring.
+# The directory is the service's RuntimeDirectory (root:i2c, 0775), so the
+# unprivileged lab user can create and remove the file.
+CLAIM_FILE = "/run/little-internet/oled.claim"
+
+# The Phase 1 BOM panel is a dual-colour 0.96" SSD1306: its top 16 pixel rows
+# emit yellow and the bottom 48 emit blue — fixed in the glass, not settable in
+# software. Yellow band: the hostname. Blue body: MAC + one IPv4 line per
+# interface. Set to 0 for a single-colour panel.
+YELLOW_H = 16
+
+# Monospace TrueType, in preference order: JetBrains Mono (ngrok's mono, from
+# fonts-jetbrains-mono on the image), then DejaVu Sans Mono as a fallback on
+# stock systems. Bold first — heavier strokes survive 1-bit rendering better.
+# Without any of these we fall back to PIL's bitmap font.
+FONTS = (
+    "/usr/share/fonts/truetype/jetbrains-mono/JetBrainsMono-Bold.ttf",
+    "/usr/share/fonts/truetype/jetbrains-mono/JetBrainsMono-Regular.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+)
+# The body font is sized once against the widest line we might render, so the
+# layout doesn't jump when an address arrives (a fixed-width font keeps the
+# columns steady too).
+WIDEST_BODY = "wlan0 255.255.255.255"
+
+
+def fit_font(sample, max_w, max_h, path=None):
+    """Largest monospace TTF at which `sample` fits, or None for the bitmap font."""
+    for fp in ([path] if path else FONTS):
+        if not fp or not os.path.exists(fp):
+            continue
+        for s in range(max_h * 2, 6, -1):
+            font = ImageFont.truetype(fp, s)
+            b = font.getbbox(sample)
+            if b[2] - b[0] <= max_w and b[3] - b[1] <= max_h:
+                return font
+    return None
+
+
+def claim_active(path):
+    """True while a live process holds the claim; clean up a stale one.
+
+    The claim file holds its writer's PID. A claim whose writer is gone (the
+    script was SIGKILLed or crashed before its cleanup ran) would pause this
+    display forever, so treat it as released and remove it.
+    """
+    try:
+        with open(path) as fh:
+            pid = int(fh.read().strip() or "0")
+    except FileNotFoundError:
+        return False
+    except (OSError, ValueError):
+        pid = 0
+    if pid > 0 and os.path.exists(f"/proc/{pid}"):
+        return True
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+    return False
+
+
+def interfaces():
+    """Map ifname -> (mac, first IPv4 or None, operstate) from `ip -json addr`."""
+    try:
+        out = subprocess.run(
+            ["ip", "-json", "addr"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        table = {}
+        for iface in json.loads(out):
+            ips = [ai["local"] for ai in iface.get("addr_info", [])
+                   if ai.get("family") == "inet" and "local" in ai]
+            table[iface.get("ifname")] = (
+                iface.get("address"),
+                ips[0] if ips else None,
+                iface.get("operstate", ""),
+            )
+        return table
+    except (subprocess.SubprocessError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def body_lines(ifnames):
+    """The blue-body text: the first interface's MAC, then one IPv4 line each.
+
+    An interface with no address distinguishes "no cable" (down) from "no
+    lease yet" (no IPv4) — the difference lesson 00 is built on.
+    """
+    table = interfaces()
+    mac = (table.get(ifnames[0]) or (None,))[0]
+    lines = [mac or f"(no {ifnames[0]})"]
+    for name in ifnames:
+        entry = table.get(name)
+        if entry is None:
+            lines.append(f"{name} (missing)")
+        elif entry[1]:
+            lines.append(f"{name} {entry[1]}")
+        elif entry[2] == "DOWN":
+            lines.append(f"{name} (down)")
+        else:
+            lines.append(f"{name} (no IPv4)")
+    return lines
+
+
+def render(device, hostname, lines, beat, head_font, body_font):
+    """Draw one frame across the panel's two colour bands (see YELLOW_H).
+
+    Yellow strip: the hostname, plus a heartbeat so a steady screen still
+    reads as "running". Blue body: the MAC/IPv4 lines, one per row slot.
+    """
+    small = ImageFont.load_default()
+    frame = Image.new("1", (device.width, device.height))
+    draw = ImageDraw.Draw(frame)
+    draw.fontmode = "1"  # no antialiasing — crisp edges on a 1-bit panel
+
+    font = head_font or small
+    b = font.getbbox(hostname)
+    draw.text((2 - b[0], (YELLOW_H - (b[3] - b[1])) // 2 - b[1]),
+              hostname, fill=1, font=font)
+    if beat:
+        draw.rectangle((device.width - 3, 1, device.width - 1, 3), fill=1)
+
+    pitch = (device.height - YELLOW_H) // len(lines)
+    font = body_font or small
+    for i, line in enumerate(lines):
+        b = font.getbbox(line)
+        y = YELLOW_H + i * pitch + (pitch - (b[3] - b[1])) // 2 - b[1]
+        draw.text((2 - b[0], y), line, fill=1, font=font)
+
+    device.display(frame)
+
+
+def open_display(args, tries=5, delay=2.0):
+    """Open the panel, retrying briefly — at boot the I2C bus can lag us."""
+    for attempt in range(tries):
+        try:
+            serial = i2c(port=args.port, address=args.address)
+            controller = sh1106 if args.controller == "sh1106" else ssd1306
+            return controller(serial, width=128, height=64)
+        except Exception as e:
+            if attempt + 1 < tries:
+                time.sleep(delay)
+                continue
+            print(f"Could not open the display: {e}")
+            print(f"Check `i2cdetect -y {args.port}` for the address, the "
+                  "wiring, and that I2C is enabled.")
+    return None
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Show this node's hostname, MAC, and IPv4 on the OLED.")
+    p.add_argument("--interfaces", nargs="+", default=["eth0", "wlan0"],
+                   help="interfaces to show, one IPv4 line each; the first "
+                        "one's MAC is shown too (default: eth0 wlan0)")
+    p.add_argument("--interval", type=float, default=1.0,
+                   help="seconds between refreshes (default 1.0)")
+    p.add_argument("--port", type=int, default=1,
+                   help="I2C bus (default 1 / /dev/i2c-1)")
+    p.add_argument("--address", type=lambda x: int(x, 0), default=0x3C,
+                   help="I2C address (default 0x3C; some modules use 0x3D)")
+    p.add_argument("--controller", choices=("ssd1306", "sh1106"), default="ssd1306",
+                   help="display controller (default ssd1306; try sh1106 if garbled)")
+    p.add_argument("--font", default=None,
+                   help="path to a .ttf (default: JetBrains Mono, then DejaVu "
+                        "Sans Mono, else the bitmap font)")
+    p.add_argument("--claim-file", default=CLAIM_FILE,
+                   help="pause while this file exists (default %(default)s)")
+    args = p.parse_args()
+
+    device = open_display(args)
+    if device is None:
+        # A node without a panel is fine — exit 0 so the service goes quietly
+        # inactive instead of restart-looping against an empty bus.
+        sys.exit(0)
+
+    body_h = (device.height - YELLOW_H) // (len(args.interfaces) + 1)
+    head_font = fit_font(socket.gethostname(), device.width - 4, YELLOW_H - 3,
+                         args.font)
+    body_font = fit_font(WIDEST_BODY, device.width - 4, body_h - 2, args.font)
+
+    # systemd stops us with SIGTERM; turn it into a clean exit so the finally
+    # below blanks the panel instead of leaving a ghost frame.
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+
+    print(f"Showing status for {', '.join(args.interfaces)} "
+          f"(refresh {args.interval}s). Ctrl-C to stop.")
+    beat = False
+    paused = False
+    try:
+        while True:
+            # An on-demand script holds the panel while the claim file exists;
+            # paint nothing and keep checking until it's released.
+            if claim_active(args.claim_file):
+                paused = True
+            else:
+                if paused:
+                    # The departing script's luma atexit cleanup switched the
+                    # panel OFF (hide), not just blank; wake it or every frame
+                    # we paint lands on dark glass.
+                    device.show()
+                    paused = False
+                render(device, socket.gethostname(),
+                       body_lines(args.interfaces), beat, head_font, body_font)
+                beat = not beat
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        print("\nDone.")
+    finally:
+        device.clear()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
New `little-internet-oled.service` paints the node's identity on the panel from boot: hostname in the yellow strip, eth0's MAC and each interface's IPv4 in the blue body (live: `(down)` / `(no IPv4)` states). Script lives in `tools/status-oled`, installed to `/opt/little-internet` by a new `07-run.sh` stage.

The on-demand scripts (`arp_oled.py`, oled tests) share the panel via a claim file in `/run/little-internet` (root:i2c 0775, so no sudo): they create it to pause the status display and remove it on exit to resume. The service wakes the panel on resume (luma's atexit powers the display off) and removes stale claims whose writer PID is dead. On-demand scripts trap SIGTERM so `finally` cleanup runs.

Tested on pi-foo-01/02: manual service install, claim handoff, SIGTERM kill, stale-claim recovery, and boot via reboot. The pi-gen stage itself is validated by the next image build.