### PR TITLE
Make the VM lab the headline virtual experience for lesson 00

### DIFF
--- a/lessons/00/README.md
+++ b/lessons/00/README.md
@@ -27,8 +27,8 @@ The scripts live on your machine where you clone this repo and drive two nodes.
 
 For anyone who's built a [hardware version](../../BOM.md) of the little internet
 themselves (bless you), those nodes will be your two Pis. If you don't want or
-can't build the hardware version, there's also a **virtualized version** you can
-run on any Linux machine (or a VM on Windows or macOS).
+can't build the hardware version, there are two **virtualized versions**: a
+two-VM lab on macOS, and a lighter network-namespace lab on Linux.
 
 ### On hardware
 
@@ -65,30 +65,33 @@ Each step is also its own script, so you can run or re-run just one:
 
 ### Virtually
 
-No Pis? `./scripts/run.sh --virtual` recreates the whole thing in software. A
-veth pair is the closest thing to a single cable—two ends, nothing in between—so
-it stands up two network namespaces (`pi-a` and `pi-b`) joined by one veth,
-walks the same steps (pausing for you between each, just like the hardware
-path), and tears it all down when you're done.
+No Pis? The closest thing to the real bench is the VM lab in
+[`scripts/virtual-vm/`](./scripts/virtual-vm/): two separate Debian VMs (two
+real kernels) joined by one QEMU socket cable. It costs a QEMU install and a
+few minutes to boot, but it delivers the beats no lighter setup can: a Layer 1
+carrier you can seat and unseat by hand (`./link.sh a off`), so the "is there
+even a wire?" question is live in software too; two genuinely independent
+machines; and cable NICs that wear the Pi's `b8:27:eb` vendor prefix. It also
+ships a live web dashboard (`./dashboard.sh`): both nodes' link state, address,
+ARP cache, and serial console, plus every frame crossing the wire. It runs on
+macOS today; see its [`README.md`](./scripts/virtual-vm/README.md) for the
+two-terminal runbook.
 
-Network namespaces are a Linux feature, so on macOS or Windows, run it inside a
-Linux VM ([colima](https://github.com/abiosoft/colima) and
-[lima](https://github.com/lima-vm/lima) both work).
+Want something quicker, or you're on Linux (or CI)? `./scripts/run.sh
+--virtual` recreates the lesson with network namespaces instead. A veth pair is
+the closest thing to a single cable—two ends, nothing in between—so it stands
+up two namespaces (`pi-a` and `pi-b`) joined by one veth, walks the same steps
+(pausing for you between each, just like the hardware path), and tears it all
+down when you're done.
 
 ```bash
 sudo ./scripts/check.sh --virtual
 sudo ./scripts/run.sh --virtual
 ```
 
-Want something closer to the real bench? There's a heavier virtual lab in
-[`scripts/virtual-vm/`](./scripts/virtual-vm/) that boots two separate Debian VMs
-(two real kernels) joined by one QEMU socket cable. It costs a QEMU install and a
-few minutes to boot, but it buys two things the namespace lab can't: genuinely
-independent machines, and a Layer 1 carrier you can seat and unseat by hand
-(`./link.sh a off`), so the "is there even a wire?" beat works in software too.
-It also ships a live web dashboard (`./dashboard.sh`): both nodes' link state,
-address, ARP cache, and serial console, plus every frame crossing the wire.
-See its [`README.md`](./scripts/virtual-vm/README.md) for the two-terminal runbook.
+Network namespaces are a Linux feature, so this path needs a Linux machine—on
+macOS or Windows, a Linux VM ([colima](https://github.com/abiosoft/colima) and
+[lima](https://github.com/lima-vm/lima) both work).
 
 ### Inspect the recorded captures
 
@@ -139,17 +142,15 @@ is to provide the pacing and instruction that a shell script cannot.
 
 #### What you can't see with virtualization
 
-A network namespace runs the same Linux stack as the Pi, but you can't see the
-physical details. That includes no:
+Even the VM lab ([`scripts/virtual-vm/`](./scripts/virtual-vm/)) has no PHY, so
+some physical details are gone in any virtual run:
 
-- Carrier or Speed/Duplex details on the `eth0` device
+- Speed/Duplex details on the `eth0` device
 - mDNS or DHCP firing on link-up
-- 42-vs-60-byte tell on whether your device sent or received ARP frames, because
-  veth doesn't pad to Ethernet's 60-byte minimum
-- `b8:27:eb`<->Raspberry Pi vendor prefix on MACs, because virtual interfaces
-  get random MACs.
+- the 42-vs-60-byte tell on whether your device sent or received ARP frames
 
-Two of these come back in the heavier VM lab
-([`scripts/virtual-vm/`](./scripts/virtual-vm/)): it drives a real carrier, so the
-link up/down beat is live (though Speed/Duplex still aren't, with no PHY), and it
-assigns the `b8:27:eb` prefix to its cable NICs, so that observation holds there.
+The namespace lab loses two more. There's no carrier to seat or unseat, and no
+`b8:27:eb`<->Raspberry Pi vendor prefix on MACs, because virtual interfaces get
+random ones. The VM lab keeps both: it drives a real carrier, so the link
+up/down beat is live, and it assigns the `b8:27:eb` prefix to its cable NICs on
+purpose.

--- a/lessons/00/README.md
+++ b/lessons/00/README.md
@@ -86,6 +86,8 @@ Want something closer to the real bench? There's a heavier virtual lab in
 few minutes to boot, but it buys two things the namespace lab can't: genuinely
 independent machines, and a Layer 1 carrier you can seat and unseat by hand
 (`./link.sh a off`), so the "is there even a wire?" beat works in software too.
+It also ships a live web dashboard (`./dashboard.sh`): both nodes' link state,
+address, ARP cache, and serial console, plus every frame crossing the wire.
 See its [`README.md`](./scripts/virtual-vm/README.md) for the two-terminal runbook.
 
 ### Inspect the recorded captures

--- a/lessons/00/scripts/virtual-vm/README.md
+++ b/lessons/00/scripts/virtual-vm/README.md
@@ -87,6 +87,31 @@ Note `seq 2` is faster than `seq 1` — that's the ARP cache. Check it with
 `ip neigh show dev eth0` on pi-a (expect `10.10.0.2 ... REACHABLE`), and note the
 `b8:27:eb` Pi vendor prefix, reproduced here on purpose.
 
+## Or watch it on the dashboard
+
+One command stands up the lab (if it isn't already) and opens a live
+black-and-white view of both nodes in your browser:
+
+```bash
+./dashboard.sh         # serves http://127.0.0.1:8099 and opens it
+```
+
+- **pi-a and pi-b side by side**: link state (`LINK UP` / `NO CARRIER`), the
+  `eth0` address, and the ARP cache, with each neighbor's state color-coded
+  (`REACHABLE` green, `STALE`/`DELAY` amber, `FAILED` red).
+- **Each node's serial console**, following the newest lines.
+- **The wire**: every frame crossing `eth0`, streamed via `tshark` and
+  color-coded (ARP amber, ICMP request green, ICMP reply cyan).
+
+Panels refresh once a second with sticky auto-scroll: pinned to the newest
+line, but you can scroll up to read without it snapping back. It pairs well
+with the runbook above: run the beats in the two SSH panes and watch the
+dashboard react, or `./link.sh a off` and watch pi-a flip to `NO CARRIER`.
+
+Ctrl-C stops the dashboard; the lab keeps running. `dashboard.py` is Python
+stdlib only (nothing to install), and the wire view uses the `tshark` that
+`lab-up.sh` puts on the nodes. Set `DASH_PORT` to serve on a different port.
+
 ## Reset a node to the blank wire
 
 ```bash


### PR DESCRIPTION
Flips lesson 00's "Virtually" section: the two-VM lab is now the default no-Pis path (real carrier, independent kernels, `b8:27:eb` NICs, dashboard), with the veth/namespace lab as the quick Linux/CI fallback. Also documents the #17 dashboard in both READMEs.