### PR TITLE
OLED improvements & wait/timeouts

### DIFF
--- a/image/stage-little-internet/00-net-tools/files/eth-dhcp.nmconnection
+++ b/image/stage-little-internet/00-net-tools/files/eth-dhcp.nmconnection
@@ -4,7 +4,12 @@
 # and mDNS — with nothing configured by the reader, exactly the moment the
 # lesson 00 diary opens on. On a two-Pi link no DHCP server answers, so eth0
 # never gets an IPv4 address: "a live wire with no identity," which is precisely
-# where the lesson begins. lessons/00/scripts/reset.sh restores this profile.
+# where the lesson begins. dhcp-timeout=10 and ra-timeout=10 keep that
+# no-answer case cheap: NetworkManager declares the activation failed only when
+# BOTH families give up, so both are capped — when a static lesson profile also
+# exists on the device, it takes over about 10 seconds after link-up instead of
+# 45 — and the phase 2 router, a real DHCP server on this wire, answers well
+# inside 10s anyway. lessons/00/scripts/reset.sh restores this profile.
 [connection]
 id=eth-dhcp
 uuid=ea4302a7-a8e0-43f3-8aae-d9bb45eed4db
@@ -15,8 +20,10 @@ autoconnect-priority=0
 
 [ipv4]
 method=auto
+dhcp-timeout=10
 never-default=true
 
 [ipv6]
 method=auto
+ra-timeout=10
 never-default=true

--- a/lessons/00/scripts/lib.sh
+++ b/lessons/00/scripts/lib.sh
@@ -100,8 +100,11 @@ node_b() { _run "$B_TGT" "$1"; }
 # imaged Pi has out of the box, and it's what makes a blank eth0 chatter the
 # instant the link comes up—the spontaneous burst the whole lesson is built on.
 # DHCP finds no server on a two-Pi link, so the wire stays addressless ("no
-# identity") while still talking. Idempotent. NetworkManager only; the netns lab
-# has no NM, so this no-ops there.
+# identity") while still talking. Each DHCP try and IPv6 RA wait is capped at
+# 10s to match the image profile (see image/.../files/eth-dhcp.nmconnection
+# for the why).
+# Idempotent. NetworkManager only; the netns lab has no NM, so this no-ops
+# there.
 baseline_block() {
 cat <<'EOF'
 command -v nmcli >/dev/null 2>&1 || exit 0
@@ -112,8 +115,11 @@ for c in eth eth0 "Wired connection 1"; do
 done
 printf '%s\n' "$existing" | grep -qx eth-dhcp || \
   nmcli connection add type ethernet ifname eth0 con-name eth-dhcp \
-    ipv4.method auto ipv6.method auto connection.autoconnect yes \
-    ipv4.never-default yes ipv6.never-default yes >/dev/null
-nmcli connection up eth-dhcp >/dev/null 2>&1 || true
+    ipv4.method auto ipv4.dhcp-timeout 10 ipv6.method auto ipv6.ra-timeout 10 \
+    connection.autoconnect yes ipv4.never-default yes ipv6.never-default yes \
+    >/dev/null
+# --wait 0: don't sit out the doomed DHCP/RA activation — on a serverless wire
+# it only ever resolves to the addressless resting state we're after anyway.
+nmcli --wait 0 connection up eth-dhcp >/dev/null 2>&1 || true
 EOF
 }

--- a/tools/status-oled/README.md
+++ b/tools/status-oled/README.md
@@ -1,21 +1,23 @@
 # Status OLED
 
 `status_oled.py` paints the node's identity on the SSD1306 from boot: the
-hostname in the yellow strip, and eth0's MAC plus the current IPv4 address of
-each interface in the blue body. With a rack of identical Pis, the panel is
-what tells you which one is which — and whose ARP entry you're looking at.
+hostname in the yellow strip, and eth0's MAC plus its current IPv4 address in
+the blue body — the address in the biggest font that fits, because that's the
+thing you read from across the bench. With a rack of identical Pis, the panel
+is what tells you which one is which — and whose ARP entry you're looking at.
 
 ```
 pi-foo-01              ← yellow strip: hostname
 ──────────────────
-d8:3a:dd:4e:aa:10      ← eth0's MAC (the node's layer-2 identity)
-eth0 10.10.0.1         ← the lab wire
-wlan0 192.168.1.77     ← your SSH path
+d8:3a:dd:4e:aa:10      ← eth0's MAC (the node's layer-2 identity), small
+10.10.0.1              ← eth0's IPv4 (the lab wire), big
 ```
 
 It refreshes once a second, so a DHCP lease landing or a cable pull shows up
-live: an interface reads `(down)` with no cable, `(no IPv4)` while it waits
-for an address — the difference lesson 00 is built on.
+live: the address line reads `(down)` with no cable, `(no IPv4)` while it
+waits for an address — the difference lesson 00 is built on. Only eth0 shows
+by default; `--interfaces eth0 wlan0` adds a line with the Wi-Fi address (your
+SSH path) back.
 
 ## On the image
 
@@ -41,7 +43,7 @@ is already in.
 ## Options
 
 - `--interfaces IF [IF ...]`: interfaces to show, one IPv4 line each; the
-  first one's MAC is shown too (default: `eth0 wlan0`)
+  first one's MAC is shown too (default: `eth0`)
 - `--interval N`: seconds between refreshes (default `1.0`)
 - `--port N`: I2C bus (default `1`)
 - `--address 0xNN`: I2C address (default `0x3c`; some modules use `0x3d`)

--- a/tools/status-oled/status_oled.py
+++ b/tools/status-oled/status_oled.py
@@ -4,9 +4,10 @@
 This is the boot-time resident of the panel: little-internet-oled.service
 starts it at boot so a powered node permanently shows who it is. The yellow
 strip gets the hostname; the blue body gets eth0's MAC (the node's layer-2
-identity in the lessons) and the current IPv4 address of each interface —
-eth0 (the lab wire) and wlan0 (your SSH path). Everything refreshes once a
-second, so a DHCP lease landing or a cable pull shows up as it happens.
+identity in the lessons) on a small row, then eth0's current IPv4 address as
+big as the panel can paint it — the address is what you read from across the
+bench. Everything refreshes once a second, so a DHCP lease landing or a cable
+pull shows up as it happens.
 
 On-demand scripts (~/arp-oled, ~/oled-test) borrow the panel by dropping a
 claim file at /run/little-internet/oled.claim; while it exists this display
@@ -16,7 +17,7 @@ Run it by hand the same way the service does:
 
     /opt/little-internet/venv/bin/python3 status_oled.py
     status_oled.py --address 0x3d --controller sh1106
-    status_oled.py --interfaces eth0        # lab wire only
+    status_oled.py --interfaces eth0 wlan0  # show the Wi-Fi address too
 """
 import argparse
 import json
@@ -39,9 +40,14 @@ CLAIM_FILE = "/run/little-internet/oled.claim"
 
 # The Phase 1 BOM panel is a dual-colour 0.96" SSD1306: its top 16 pixel rows
 # emit yellow and the bottom 48 emit blue — fixed in the glass, not settable in
-# software. Yellow band: the hostname. Blue body: MAC + one IPv4 line per
-# interface. Set to 0 for a single-colour panel.
+# software. Yellow band: the hostname. Blue body: MAC + IPv4. Set to 0 for a
+# single-colour panel.
 YELLOW_H = 16
+
+# Height of the MAC row at the top of the blue body. Everything below it goes
+# to the IPv4 line(s), which get the biggest font that fits — the address is
+# the thing this panel exists to show.
+MAC_H = 16
 
 # Monospace TrueType, in preference order: JetBrains Mono (ngrok's mono, from
 # fonts-jetbrains-mono on the image), then DejaVu Sans Mono as a fallback on
@@ -53,10 +59,10 @@ FONTS = (
     "/usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf",
     "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
 )
-# The body font is sized once against the widest line we might render, so the
-# layout doesn't jump when an address arrives (a fixed-width font keeps the
-# columns steady too).
-WIDEST_BODY = "wlan0 255.255.255.255"
+# The MAC row's font is sized once against a full-width MAC so its layout
+# never jumps. The IPv4 font is instead fitted to the text actually shown —
+# lab addresses are short, so they render far bigger than the worst case.
+MAC_SAMPLE = "88:88:88:88:88:88"
 
 
 def fit_font(sample, max_w, max_h, path=None):
@@ -116,33 +122,37 @@ def interfaces():
         return {}
 
 
-def body_lines(ifnames):
-    """The blue-body text: the first interface's MAC, then one IPv4 line each.
+def body(ifnames):
+    """The blue-body text: the first interface's MAC, plus one IPv4 line each.
 
     An interface with no address distinguishes "no cable" (down) from "no
-    lease yet" (no IPv4) — the difference lesson 00 is built on.
+    lease yet" (no IPv4) — the difference lesson 00 is built on. With one
+    interface the line is just the address, full width; with several, each
+    line carries its interface name.
     """
     table = interfaces()
-    mac = (table.get(ifnames[0]) or (None,))[0]
-    lines = [mac or f"(no {ifnames[0]})"]
+    mac = (table.get(ifnames[0]) or (None,))[0] or f"(no {ifnames[0]})"
+    lines = []
     for name in ifnames:
         entry = table.get(name)
         if entry is None:
-            lines.append(f"{name} (missing)")
+            text = "(missing)"
         elif entry[1]:
-            lines.append(f"{name} {entry[1]}")
+            text = entry[1]
         elif entry[2] == "DOWN":
-            lines.append(f"{name} (down)")
+            text = "(down)"
         else:
-            lines.append(f"{name} (no IPv4)")
-    return lines
+            text = "(no IPv4)"
+        lines.append(f"{name} {text}" if len(ifnames) > 1 else text)
+    return mac, lines
 
 
-def render(device, hostname, lines, beat, head_font, body_font):
+def render(device, hostname, mac, ips, beat, head_font, mac_font, ip_font):
     """Draw one frame across the panel's two colour bands (see YELLOW_H).
 
     Yellow strip: the hostname, plus a heartbeat so a steady screen still
-    reads as "running". Blue body: the MAC/IPv4 lines, one per row slot.
+    reads as "running". Blue body: the MAC on its small row, then the IPv4
+    line(s) as big as they fit.
     """
     small = ImageFont.load_default()
     frame = Image.new("1", (device.width, device.height))
@@ -156,11 +166,16 @@ def render(device, hostname, lines, beat, head_font, body_font):
     if beat:
         draw.rectangle((device.width - 3, 1, device.width - 1, 3), fill=1)
 
-    pitch = (device.height - YELLOW_H) // len(lines)
-    font = body_font or small
-    for i, line in enumerate(lines):
+    font = mac_font or small
+    b = font.getbbox(mac)
+    draw.text((2 - b[0], YELLOW_H + (MAC_H - (b[3] - b[1])) // 2 - b[1]),
+              mac, fill=1, font=font)
+
+    pitch = (device.height - YELLOW_H - MAC_H) // len(ips)
+    font = ip_font or small
+    for i, line in enumerate(ips):
         b = font.getbbox(line)
-        y = YELLOW_H + i * pitch + (pitch - (b[3] - b[1])) // 2 - b[1]
+        y = YELLOW_H + MAC_H + i * pitch + (pitch - (b[3] - b[1])) // 2 - b[1]
         draw.text((2 - b[0], y), line, fill=1, font=font)
 
     device.display(frame)
@@ -186,9 +201,9 @@ def open_display(args, tries=5, delay=2.0):
 def main():
     p = argparse.ArgumentParser(
         description="Show this node's hostname, MAC, and IPv4 on the OLED.")
-    p.add_argument("--interfaces", nargs="+", default=["eth0", "wlan0"],
+    p.add_argument("--interfaces", nargs="+", default=["eth0"],
                    help="interfaces to show, one IPv4 line each; the first "
-                        "one's MAC is shown too (default: eth0 wlan0)")
+                        "one's MAC is shown too (default: eth0)")
     p.add_argument("--interval", type=float, default=1.0,
                    help="seconds between refreshes (default 1.0)")
     p.add_argument("--port", type=int, default=1,
@@ -210,10 +225,14 @@ def main():
         # inactive instead of restart-looping against an empty bus.
         sys.exit(0)
 
-    body_h = (device.height - YELLOW_H) // (len(args.interfaces) + 1)
+    ip_h = (device.height - YELLOW_H - MAC_H) // len(args.interfaces)
     head_font = fit_font(socket.gethostname(), device.width - 4, YELLOW_H - 3,
                          args.font)
-    body_font = fit_font(WIDEST_BODY, device.width - 4, body_h - 2, args.font)
+    mac_font = fit_font(MAC_SAMPLE, device.width - 4, MAC_H - 2, args.font)
+    # The IPv4 font is refitted when the widest line changes, so a short lab
+    # address paints far bigger than 255.255.255.255 would. The cache stays
+    # tiny — a node sees a handful of distinct addresses per boot.
+    ip_fonts = {}
 
     # systemd stops us with SIGTERM; turn it into a clean exit so the finally
     # below blanks the panel instead of leaving a ghost frame.
@@ -236,8 +255,13 @@ def main():
                     # we paint lands on dark glass.
                     device.show()
                     paused = False
-                render(device, socket.gethostname(),
-                       body_lines(args.interfaces), beat, head_font, body_font)
+                mac, ips = body(args.interfaces)
+                widest = max(ips, key=len)
+                if widest not in ip_fonts:
+                    ip_fonts[widest] = fit_font(widest, device.width - 4,
+                                                ip_h - 2, args.font)
+                render(device, socket.gethostname(), mac, ips, beat,
+                       head_font, mac_font, ip_fonts[widest])
                 beat = not beat
             time.sleep(args.interval)
     except KeyboardInterrupt:


### PR DESCRIPTION
- Panel shows eth0 only: MAC on a small row, IPv4 in the biggest font that fits (`--interfaces eth0 wlan0` restores the Wi-Fi line)
- `eth-dhcp` caps DHCP and IPv6 RA waits at 10s, so the static lesson profile takes over ~10s after link-up instead of 45
- Lesson reset no longer blocks on the doomed activation (`nmcli --wait 0`): ~2min → seconds

Already running on pi-foo-01/02.