### PR TITLE
Run the VM lab on Linux and Windows (WSL2), not just macOS

### DIFF
--- a/lessons/00/scripts/virtual-vm/README.md
+++ b/lessons/00/scripts/virtual-vm/README.md
@@ -25,11 +25,17 @@ hardware image enforces — so anything you see on `eth0` really crossed the wir
 
 ## Requirements
 
-- A Mac with **QEMU**: `brew install qemu` (HVF acceleration, no sudo needed).
-  Apple Silicon and Intel both work — the lab picks the matching QEMU binary
-  and Debian image automatically.
-- Built-in `hdiutil`, `python3`, and `curl` — already present on macOS.
-- ~2GB RAM free and ~2GB disk. First boot needs internet (downloads the image
+Runs on **macOS** and **Linux**, and on **Windows** via WSL2 (which is Linux). The
+lab auto-detects your CPU and picks the matching QEMU binary and Debian image
+(Apple Silicon / arm64 or Intel / amd64).
+
+- **QEMU**, plus a tool to build the seed ISO:
+  - macOS: `brew install qemu` (uses HVF, no sudo; `hdiutil` is built in).
+  - Debian/Ubuntu: `sudo apt-get install qemu-system xorriso` (uses KVM; you need
+    access to `/dev/kvm`, e.g. add yourself to the `kvm` group).
+  - Windows: do everything inside **WSL2** (Ubuntu), then follow the Linux steps.
+- `python3` and `curl` (built into macOS; preinstalled on most Linux).
+- About 2GB RAM free and 2GB disk. First boot needs internet (downloads the image
   and installs `tcpdump` in the guests).
 
 ## Bring it up

--- a/lessons/00/scripts/virtual-vm/common.sh
+++ b/lessons/00/scripts/virtual-vm/common.sh
@@ -31,18 +31,39 @@ WIRE_PORT="${WIRE_PORT:-10000}"
 # PATH (e.g. the Android SDK's) can't be picked up by accident.
 QEMU="${QEMU:-$QEMU_DEFAULT}"
 if ! command -v "$QEMU" >/dev/null 2>&1; then
-  echo "error: '$QEMU' not found. Install QEMU first:  brew install qemu" >&2
+  echo "error: '$QEMU' not found. Install QEMU (macOS: brew install qemu; Debian/Ubuntu: sudo apt-get install qemu-system)." >&2
   exit 1
 fi
 QEMU_IMG="${QEMU_IMG:-$(dirname "$(command -v "$QEMU")")/qemu-img}"
+
+# Accelerator + CPU model by host OS. macOS uses Hypervisor.framework (HVF);
+# Linux uses KVM when /dev/kvm is usable, otherwise slow tcg emulation. Windows
+# runs this inside WSL2, which presents as Linux.
+case "$(uname -s)" in
+  Darwin) ACCEL=hvf ;;
+  Linux)
+    if [ -w "${KVM_DEV:-/dev/kvm}" ]; then ACCEL=kvm
+    else ACCEL=tcg; echo "warning: /dev/kvm not usable (add yourself to the kvm group?); using slow tcg emulation" >&2; fi ;;
+  MINGW*|MSYS*|CYGWIN*)
+    echo "error: native Windows shells aren't supported. Run this inside WSL2 (Ubuntu), which uses the Linux path." >&2; exit 1 ;;
+  *) ACCEL=tcg; echo "warning: unrecognized host OS $(uname -s); using tcg emulation" >&2 ;;
+esac
+# -cpu host needs a hardware accelerator; tcg emulation takes the generic model.
+if [ "$ACCEL" = tcg ]; then CPU=max; else CPU=host; fi
 
 # x86_64 QEMU has a default board and BIOS; aarch64 has neither, so it gets the
 # generic "virt" machine plus the EDK2 UEFI firmware that ships with QEMU.
 # (Always non-empty: bash 3.2, macOS's default, chokes on empty arrays + set -u.)
 if [ "$GUEST_ARCH" = arm64 ]; then
-  EDK2_FW="$(dirname "$(command -v "$QEMU")")/../share/qemu/edk2-aarch64-code.fd"
-  if [ ! -f "$EDK2_FW" ]; then
-    echo "error: EDK2 firmware not found at $EDK2_FW (reinstall QEMU?)" >&2
+  EDK2_FW=""
+  for _fw in "$(dirname "$(command -v "$QEMU")")/../share/qemu/edk2-aarch64-code.fd" \
+             /usr/share/qemu/edk2-aarch64-code.fd \
+             /usr/share/AAVMF/AAVMF_CODE.fd \
+             /usr/share/edk2/aarch64/QEMU_EFI.fd; do
+    [ -f "$_fw" ] && { EDK2_FW="$_fw"; break; }
+  done
+  if [ -z "$EDK2_FW" ]; then
+    echo "error: EDK2 aarch64 firmware not found (reinstall QEMU, or install the EDK2/AAVMF package)" >&2
     exit 1
   fi
   machine_args=( -M virt -bios "$EDK2_FW" )
@@ -117,9 +138,21 @@ ethernets:
 EOF
 
   rm -f "$iso"
-  # hdiutil (built into macOS) writes an ISO9660+Joliet image labeled CIDATA,
-  # which is what cloud-init's NoCloud datasource looks for.
-  hdiutil makehybrid -quiet -o "$iso" -iso -joliet -default-volume-name CIDATA "$dir"
+  # An ISO9660+Joliet image labeled CIDATA is what cloud-init's NoCloud datasource
+  # looks for. hdiutil ships with macOS; xorriso/genisoimage/mkisofs cover Linux.
+  if command -v hdiutil >/dev/null 2>&1; then
+    hdiutil makehybrid -quiet -o "$iso" -iso -joliet -default-volume-name CIDATA "$dir"
+  elif command -v xorriso >/dev/null 2>&1; then
+    xorriso -as mkisofs -quiet -o "$iso" -V CIDATA -J -r "$dir"
+  elif command -v genisoimage >/dev/null 2>&1; then
+    genisoimage -quiet -o "$iso" -V CIDATA -J -r "$dir"
+  elif command -v mkisofs >/dev/null 2>&1; then
+    mkisofs -quiet -o "$iso" -V CIDATA -J -r "$dir"
+  else
+    echo "error: need hdiutil (macOS) or xorriso/genisoimage/mkisofs (Linux) to build the seed ISO." >&2
+    echo "  Debian/Ubuntu: sudo apt-get install xorriso" >&2
+    exit 1
+  fi
   rm -rf "$dir"
 }
 
@@ -130,8 +163,8 @@ boot_node() {
   "$QEMU" \
     -name "pi-$n" \
     "${machine_args[@]}" \
-    -accel hvf \
-    -cpu host \
+    -accel "$ACCEL" \
+    -cpu "$CPU" \
     -m 1024 -smp 2 \
     -drive if=virtio,format=qcow2,file="$LAB_HOME/pi-$n.qcow2" \
     -drive if=virtio,format=raw,file="$LAB_HOME/seed-$n.iso",readonly=on \

--- a/lessons/00/scripts/virtual-vm/dashboard.sh
+++ b/lessons/00/scripts/virtual-vm/dashboard.sh
@@ -16,5 +16,6 @@ if ! pgrep -f qemu-system >/dev/null 2>&1; then
 fi
 
 echo "opening dashboard at http://127.0.0.1:$DASH_PORT"
-( sleep 1; open "http://127.0.0.1:$DASH_PORT" >/dev/null 2>&1 || true ) &
+( sleep 1; open "http://127.0.0.1:$DASH_PORT" >/dev/null 2>&1 \
+  || xdg-open "http://127.0.0.1:$DASH_PORT" >/dev/null 2>&1 || true ) &
 exec python3 ./dashboard.py

--- a/lessons/00/scripts/virtual-vm/tests/test-detect.sh
+++ b/lessons/00/scripts/virtual-vm/tests/test-detect.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Unit tests for the host-OS detection in common.sh: the accelerator, CPU model,
+# and guest arch it picks per platform. Runs common.sh against a fake `uname` and
+# fake QEMU binaries on PATH, so no real VM (or KVM/HVF) is needed. Covers the
+# cross-platform branching only; the ISO-tool and browser-open fallbacks are plain
+# `command -v` chains and are not unit-tested here.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+COMMON="$(dirname "$HERE")/common.sh"
+
+# Scratch tree: fake uname + qemu binaries in bin/, a fake EDK2 firmware in
+# share/qemu/ (where common.sh looks for the arm64 case). Removed on exit.
+FAKE="$(mktemp -d)"
+trap 'rm -rf "$FAKE"' EXIT
+mkdir -p "$FAKE/bin" "$FAKE/share/qemu"
+cat > "$FAKE/bin/uname" <<'SH'
+#!/bin/sh
+case "$1" in
+  -s) echo "${FAKE_UNAME_S:-Darwin}" ;;
+  -m) echo "${FAKE_UNAME_M:-x86_64}" ;;
+  *)  echo Fake ;;
+esac
+SH
+for q in qemu-system-x86_64 qemu-system-aarch64 qemu-img; do
+  printf '#!/bin/sh\nexit 0\n' > "$FAKE/bin/$q"
+done
+chmod +x "$FAKE/bin/"*
+: > "$FAKE/share/qemu/edk2-aarch64-code.fd"
+
+KVM_YES="$FAKE/kvm-present"; : > "$KVM_YES"   # writable file -> KVM available
+KVM_NO="$FAKE/kvm-absent"                      # does not exist -> no KVM
+
+# detect UNAME_S UNAME_M KVM_DEV -> prints "ACCEL CPU GUEST_ARCH"
+detect() {
+  env -i HOME="$HOME" PATH="$FAKE/bin:/usr/bin:/bin" \
+    FAKE_UNAME_S="$1" FAKE_UNAME_M="$2" KVM_DEV="$3" \
+    bash -c 'source "'"$COMMON"'" >/dev/null 2>&1; echo "$ACCEL $CPU $GUEST_ARCH"'
+}
+
+pass=0; fail=0
+check() { # description expected actual
+  if [ "$2" = "$3" ]; then echo "PASS  $1"; pass=$((pass + 1))
+  else echo "FAIL  $1 (expected [$2], got [$3])"; fail=$((fail + 1)); fi
+}
+
+check "macOS amd64 -> hvf/host"          "hvf host amd64"  "$(detect Darwin x86_64  "$KVM_NO")"
+check "Linux amd64 with KVM -> kvm/host" "kvm host amd64"  "$(detect Linux  x86_64  "$KVM_YES")"
+check "Linux amd64 no KVM -> tcg/max"    "tcg max amd64"   "$(detect Linux  x86_64  "$KVM_NO")"
+check "Linux arm64 with KVM -> kvm/arm64" "kvm host arm64" "$(detect Linux  aarch64 "$KVM_YES")"
+
+# A native Windows shell (Git Bash / MSYS) must refuse and point at WSL2.
+env -i HOME="$HOME" PATH="$FAKE/bin:/usr/bin:/bin" \
+  FAKE_UNAME_S="MINGW64_NT-10.0" FAKE_UNAME_M="x86_64" KVM_DEV="$KVM_NO" \
+  bash -c 'source "'"$COMMON"'"' >/dev/null 2>&1
+if [ "$?" -ne 0 ]; then echo "PASS  native Windows shell refused (use WSL2)"; pass=$((pass + 1))
+else echo "FAIL  native Windows shell was not refused"; fail=$((fail + 1)); fi
+
+echo "----"
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What this does

Makes the two-VM lab scripts run on **Linux** and **Windows (via WSL2)**, not just
macOS. The scripts detect the host at runtime and pick the right pieces, so it is
one codebase with no per-OS variants and nothing to configure.

## What changed

- `common.sh`: detects the host OS and selects
  - accelerator: HVF on macOS, KVM on Linux (or slow tcg if `/dev/kvm` is not usable)
  - seed-ISO tool: `hdiutil` on macOS, `xorriso`/`genisoimage`/`mkisofs` on Linux
  - EDK2 arm64 firmware: searches the Homebrew and common Linux paths
  - native Windows shells (Git Bash / MSYS) are refused with a pointer to WSL2
- `dashboard.sh`: falls back from `open` to `xdg-open` on Linux
- `tests/test-detect.sh`: unit tests for the OS detection (accel, CPU, arch, and the
  Windows refusal), using a fake `uname` and QEMU so no VM is needed
- `README.md`: requirements for macOS, Linux, and Windows (WSL2)

## Testing

- macOS: unchanged, verified (still HVF and `hdiutil`).
- Detection: `tests/test-detect.sh` passes 5/5.
- Linux seed-ISO build: verified on real Linux (Ubuntu) that both `xorriso` and
  `genisoimage` produce a cloud-init NoCloud image (label `cidata`, the three seed
  files with correct names).
- Not run end to end: an actual KVM-accelerated boot on Linux, which needs a host
  with hardware virtualization. `-accel kvm -cpu host` is standard QEMU.

Windows is supported via WSL2 (which presents as Linux); a native Windows
(PowerShell / WHPX) port is out of scope.
